### PR TITLE
UPF Port Mapping Fix

### DIFF
--- a/5gc/upf_u_complete/upf_u.c
+++ b/5gc/upf_u_complete/upf_u.c
@@ -181,7 +181,7 @@ parseMAC(const char *config_path) {
 
     fclose(file);
 
-    UTLT_Info("UPF port map (from upf_u.txt): ACCESS=%d CORE=%d SGI=%d",
+    UTLT_Debug("UPF port map (from upf_u.txt): ACCESS=%d CORE=%d SGI=%d",
               g_access_port, g_core_port, g_sgi_port);
 }
 

--- a/5gc/upf_u_complete/upf_u.c
+++ b/5gc/upf_u_complete/upf_u.c
@@ -72,6 +72,15 @@ uint8_t DnMac[RTE_ETHER_ADDR_LEN];
 uint8_t AnMac[RTE_ETHER_ADDR_LEN];
 int SELF_IP;
 
+/* --- Runtime port map (deploy-time configurable) --- */
+enum { IF_UNKNOWN = -1 };
+
+static int16_t g_access_port = 0;  
+static int16_t g_core_port   = 1; 
+static int16_t g_sgi_port    = 1;
+
+
+
 char *
 convertToIpAddress(uint32_t big_endian_value) {
     static char ip_string[16];
@@ -110,8 +119,7 @@ parseIpv4Address(const char *addrStr) {
 
 void
 parseMAC(const char *config_path) {
-    FILE *file;
-    file = fopen(config_path, "r");
+    FILE *file = fopen(config_path, "r");
     if (file == NULL) {
         fprintf(stderr, "Error: failed to open file %s\n", config_path);
         exit(EXIT_FAILURE);
@@ -122,65 +130,74 @@ parseMAC(const char *config_path) {
     int DNvalues[6];
     int ANvalues[6];
 
-    while (fgets(line, 256, file) != NULL) {
+    while (fgets(line, sizeof(line), file) != NULL) {
         linenum++;
-        // printf("Line: %d    String: %s\n", linenum, line);
+
+        char *p = line;
+        while (*p == ' ' || *p == '\t') p++;
+
+        if (strncmp(p, "ACCESS_PORT=", 12) == 0) {
+            int v = atoi(p + 12);
+            if (v >= 0 && v <= UINT8_MAX) g_access_port = (int16_t)v;
+            continue;
+        }
+        if (strncmp(p, "CORE_PORT=", 10) == 0) {
+            int v = atoi(p + 10);
+            if (v >= 0 && v <= UINT8_MAX) {
+                g_core_port = (int16_t)v;
+                g_sgi_port  = (int16_t)v;
+            }
+            continue;
+        }
 
         if (linenum == 2) {
             /* DN MAC Address */
-            if (sscanf(line, "%x:%x:%x:%x:%x:%x%*c", &DNvalues[0], &DNvalues[1], &DNvalues[2], &DNvalues[3],
-                   &DNvalues[4], &DNvalues[5]) == 6) {
-                int i;
-                for (i = 0; i < 6; ++i) {
-                    // printf("%d -> %u\n", DNvalues[i], (uint8_t) DNvalues[i]);
-                    DnMac[i] = (uint8_t)DNvalues[i];
-                    // printf("%u\n", DnMac[i]);
-                }
+            if (sscanf(p, "%x:%x:%x:%x:%x:%x%*c",
+                       &DNvalues[0], &DNvalues[1], &DNvalues[2],
+                       &DNvalues[3], &DNvalues[4], &DNvalues[5]) == 6) {
+                for (int i = 0; i < 6; ++i) DnMac[i] = (uint8_t)DNvalues[i];
             } else {
-                fprintf(stderr, "[Parse MAC] could not parse %s\n", line);
+                fprintf(stderr, "[Parse MAC] could not parse DN MAC from: %s", p);
             }
         }
 
         if (linenum == 4) {
             /* AN MAC Address */
-            if (sscanf(line, "%x:%x:%x:%x:%x:%x%*c", &ANvalues[0], &ANvalues[1], &ANvalues[2], &ANvalues[3],
-                   &ANvalues[4], &ANvalues[5]) == 6) {
-                int j;
-                for (j = 0; j < 6; ++j) {
-                    // printf("%d -> %u\n", ANvalues[j], (uint8_t) ANvalues[j]);
-                    AnMac[j] = (uint8_t)ANvalues[j];
-                    // printf("%u\n", AnMac[j]);
-                }
+            if (sscanf(p, "%x:%x:%x:%x:%x:%x%*c",
+                       &ANvalues[0], &ANvalues[1], &ANvalues[2],
+                       &ANvalues[3], &ANvalues[4], &ANvalues[5]) == 6) {
+                for (int j = 0; j < 6; ++j) AnMac[j] = (uint8_t)ANvalues[j];
             } else {
-                fprintf(stderr, "[Parse MAC] could not parse %s\n", line);
+                fprintf(stderr, "[Parse MAC] could not parse AN MAC from: %s", p);
             }
         }
-        if ((linenum == 6)) {
-            if (parseIpv4Address(line)) {
+
+        if (linenum == 6) {
+            if (parseIpv4Address(p)) {
                 UTLT_Error("Parse IP address failed\n");
             }
         }
     }
 
     fclose(file);
-};
+
+    UTLT_Info("UPF port map (from upf_u.txt): ACCESS=%d CORE=%d SGI=%d",
+              g_access_port, g_core_port, g_sgi_port);
+}
+
 
 #define MAX_OF_BUFFER_PACKET_SIZE 30000
 struct rte_mbuf *buffer[MAX_OF_BUFFER_PACKET_SIZE];
 uint32_t buffer_length = 0;
 
-static inline uint8_t
+static inline int16_t
 SourceInterfaceToPort(uint8_t interface) {
     switch (interface) {
-        case SRC_INTF_ACCESS:
-            return 0;
-        case SRC_INTF_CORE:
-        case SRC_INTF_SGI_LAN:
-            return 1;
+        case SRC_INTF_ACCESS:   return g_access_port;
+        case SRC_INTF_CORE:     return g_core_port;
+        case SRC_INTF_SGI_LAN:  return g_sgi_port;
         case SRC_INTF_CP:
-            return -1;
-        default:
-            return -1;
+        default:                return IF_UNKNOWN;
     }
 }
 

--- a/5gc/upf_u_complete/upf_u.txt
+++ b/5gc/upf_u_complete/upf_u.txt
@@ -1,6 +1,8 @@
 # DN MAC Address
-3c:fd:fe:b3:13:05
+3c:fd:fe:b0:f1:f4
 # AN MAC Address
-3c:fd:fe:ac:fb:0c
+3c:fd:fe:b0:f5:4d
 # UPF ID Address
 192.168.1.2
+ACCESS_PORT=1
+CORE_PORT=0


### PR DESCRIPTION
### Summary
This change fixes incorrect UL/DL classification in **UPF-U** caused by hard-coded port mappings between `sourceInterface` (ACCESS/CORE) and DPDK port IDs.

### Problem
Previously, `SourceInterfaceToPort()` assumed:

```
SRC_INTF_ACCESS → port 0  
SRC_INTF_CORE   → port 1
```
This was fragile. On CloudLab (and any environment where `dpdk-devbind` enumerates NICs differently), the AN–CN link could end up on port 1 instead of 0. That caused UL packets to be misinterpreted as DL, and vice versa, leading to wrong PDR matches and packet drops.

### Solution
Removed the hard-coded assumptions and made the mapping **runtime configurable**:

- Added three globals `g_access_port`, `g_core_port`, `g_sgi_port` (default 0/1 for backwards compatibility).
- Extended `parseMAC()` to parse two new optional lines in `upf_u.txt`:

```
ACCESS_PORT=1
CORE_PORT=0
```
This way, developer or anyone setting up L25GC+ can fix mapping via config without code changes.

