### PR TITLE
UPF-U: switch config to YAML and wire libyaml parsing

### DIFF
--- a/5gc/meson.build
+++ b/5gc/meson.build
@@ -12,11 +12,18 @@ foreach nf : l25gc_nfs
 
     subdir(nf)
 
+    # base deps for every NF
+    deps = [ onvm_dpdk_dep, onvm_nflib_dep, onvm_l25gc_dep, rt_dep ]
+
+    if nf == 'upf_u_complete'
+        deps += upf_u_link_deps
+    endif
+
     executable(
         name,
         sources,
         include_directories: includes,
-        dependencies: [onvm_dpdk_dep, onvm_nflib_dep, onvm_l25gc_dep, rt_dep],
+        dependencies: deps,
         install: true,
         install_tag: 'onvm',
         install_dir: onvm_output_dir + '/nf/' + nf

--- a/5gc/upf_u_complete/config/upf_u.yaml
+++ b/5gc/upf_u_complete/config/upf_u.yaml
@@ -1,0 +1,13 @@
+info:
+  version: 1.0.0
+  description: L25GC-plus UPF-U dataplane configuration
+
+configuration:
+  dataplane:
+    dn_mac: "3c:fd:fe:b4:fe:21"
+    an_mac: "3c:fd:fe:b5:00:14"
+    upf_ip: "192.168.1.2"
+
+    ports:
+      access: 0                     # ACCESS_PORT
+      core: 1                       # CORE_PORT (SGi follows CORE)

--- a/5gc/upf_u_complete/meson.build
+++ b/5gc/upf_u_complete/meson.build
@@ -1,3 +1,8 @@
 sources = files(
-    'upf_u.c'
+    'upf_u.c',
+    'upf_u_config.c'
 )
+
+upf_u_link_deps = [
+  dependency('yaml-0.1', version: '>=0.2.2', required: true),
+]

--- a/5gc/upf_u_complete/upf_u.c
+++ b/5gc/upf_u_complete/upf_u.c
@@ -40,6 +40,8 @@
 #include "onvm_pkt_helper.h"
 #include "rte_meter.h"
 
+#include "upf_u_config.h"
+
 #define NF_TAG "upf_u"
 
 // #if 0
@@ -75,9 +77,9 @@ int SELF_IP;
 /* --- Runtime port map (deploy-time configurable) --- */
 enum { IF_UNKNOWN = -1 };
 
-static int16_t g_access_port = 0;
-static int16_t g_core_port   = 1;
-static int16_t g_sgi_port    = 1;
+int16_t g_access_port = 0;
+int16_t g_core_port   = 0;
+int16_t g_sgi_port    = 0;
 
 
 
@@ -1096,12 +1098,19 @@ main(int argc, char *argv[]) {
         rte_exit(EXIT_FAILURE, "Cannot get MAC address: err=%d, port=%u\n", ret, 1);
 
     // Parse DN & AN MAC address from upf_u.txt
-    const char *config_path = "upf_u.txt";  // default
+    //const char *config_path = "upf_u.txt";  // default
+
+    const char *config_path = "config/upf_u.yaml";
+
     if (argc > arg_offset + 1) {
         config_path = argv[arg_offset + 1];
     }
-    printf("Using config path: %s\n", config_path);  // print the path
-    parseMAC(config_path);
+    printf("[UPF-U] Using config: %s\n", config_path);
+    //parseMAC(config_path);
+    UpfU_LoadAndParseConfig(config_path);
+
+    /* UTLT_Info("[UPF-U][CONFIG] Port map: ACCESS=%d CORE=%d SGI=%d",
+          g_access_port, g_core_port, g_sgi_port); */
 
     // 8c:dc:d4:ac:6c:7d
     dn_eth.addr_bytes[0] = DnMac[0];

--- a/5gc/upf_u_complete/upf_u_config.c
+++ b/5gc/upf_u_complete/upf_u_config.c
@@ -1,0 +1,186 @@
+#include "upf_u_config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <yaml.h>
+
+extern uint8_t  DnMac[6];
+extern uint8_t  AnMac[6];
+extern uint32_t SELF_IP;
+extern int16_t  g_access_port;
+extern int16_t  g_core_port;
+extern int16_t  g_sgi_port;
+
+
+static void fatal(const char *msg) {
+    fprintf(stderr, "[UPF-U][CONFIG] %s\n", msg);
+    exit(EXIT_FAILURE);
+}
+
+static int parse_mac(const char *txt, uint8_t out[6]) {
+    int v[6];
+    if (sscanf(txt, " %x:%x:%x:%x:%x:%x ", &v[0],&v[1],&v[2],&v[3],&v[4],&v[5]) != 6) return -1;
+    for (int i=0;i<6;i++) out[i] = (uint8_t)v[i];
+    return 0;
+}
+
+
+int parseIpv4Address(const char *s);
+
+// --- libyaml DOM helpers ---
+
+static yaml_node_t* doc_root(yaml_document_t *doc) {
+    // The first (and only) document's root is node id 1 for libyaml DOM
+    if (!doc || doc->nodes.top <= doc->nodes.start) return NULL;
+    return yaml_document_get_root_node(doc);
+}
+
+// Look up a mapping value by 'key' string. Returns the value node or NULL.
+static yaml_node_t* map_get(yaml_document_t *doc, yaml_node_t *map, const char *key) {
+    if (!map || map->type != YAML_MAPPING_NODE) return NULL;
+    for (yaml_node_pair_t *p = map->data.mapping.pairs.start;
+         p < map->data.mapping.pairs.top; ++p) {
+        yaml_node_t *k = yaml_document_get_node(doc, p->key);
+        yaml_node_t *v = yaml_document_get_node(doc, p->value);
+        if (!k || k->type != YAML_SCALAR_NODE) continue;
+        if (k->data.scalar.value && strcmp((const char*)k->data.scalar.value, key) == 0)
+            return v;
+    }
+    return NULL;
+}
+
+static const char* scalar_str(yaml_node_t *n) {
+    if (!n || n->type != YAML_SCALAR_NODE) return NULL;
+    return (const char*)n->data.scalar.value;
+}
+
+// --- Parse logic: configuration -> dataplane -> fields ---
+
+static int do_parse(yaml_document_t *doc) {
+    yaml_node_t *root = doc_root(doc);
+    if (!root || root->type != YAML_MAPPING_NODE)
+        return -1;
+
+    yaml_node_t *info = map_get(doc, root, "info");           // optional
+    (void)info;
+
+    yaml_node_t *cfg  = map_get(doc, root, "configuration");
+    if (!cfg || cfg->type != YAML_MAPPING_NODE)
+        return -1;
+
+    yaml_node_t *dp   = map_get(doc, cfg,  "dataplane");
+    if (!dp || dp->type != YAML_MAPPING_NODE)
+        return -1;
+
+    // dn_mac
+    {
+        yaml_node_t *n = map_get(doc, dp, "dn_mac");
+        const char *s = scalar_str(n);
+        if (!s || parse_mac(s, DnMac) != 0) {
+            fprintf(stderr, "[UPF-U][CONFIG] invalid dn_mac\n");
+            return -1;
+        }
+    }
+
+    // an_mac
+    {
+        yaml_node_t *n = map_get(doc, dp, "an_mac");
+        const char *s = scalar_str(n);
+        if (!s || parse_mac(s, AnMac) != 0) {
+            fprintf(stderr, "[UPF-U][CONFIG] invalid an_mac\n");
+            return -1;
+        }
+    }
+
+    // upf_ip
+    {
+        yaml_node_t *n = map_get(doc, dp, "upf_ip");
+        if (!n || n->type != YAML_SCALAR_NODE) {
+            fprintf(stderr, "[UPF-U][CONFIG] missing upf_ip\n");
+            return -1;
+        }
+        const unsigned char *p = n->data.scalar.value;
+        size_t len = n->data.scalar.length;
+
+        char buf[64];
+        if (len >= sizeof(buf)) len = sizeof(buf) - 1;
+        memcpy(buf, p, len);
+        buf[len] = '\0';
+
+        if (parseIpv4Address(buf)) {
+            fprintf(stderr, "[UPF-U][CONFIG] invalid upf_ip\n");
+            return -1;
+        }
+    }
+
+    // dataplane.ports
+    {
+        yaml_node_t *ports = map_get(doc, dp, "ports");
+        if (!ports || ports->type != YAML_MAPPING_NODE) {
+            fprintf(stderr, "[UPF-U][CONFIG] missing dataplane.ports\n");
+            return -1;
+        }
+        // access
+        {
+            yaml_node_t *n = map_get(doc, ports, "access");
+            const char *s = scalar_str(n);
+            if (!s) { fprintf(stderr, "[UPF-U][CONFIG] missing ports.access\n"); return -1; }
+            int v = atoi(s);
+            if (v < 0 || v > 255) { fprintf(stderr, "[UPF-U][CONFIG] bad ports.access\n"); return -1; }
+            g_access_port = (int16_t)v;
+        }
+        // core  (SGi follows CORE)
+        {
+            yaml_node_t *n = map_get(doc, ports, "core");
+            const char *s = scalar_str(n);
+            if (!s) { fprintf(stderr, "[UPF-U][CONFIG] missing ports.core\n"); return -1; }
+            int v = atoi(s);
+            if (v < 0 || v > 255) { fprintf(stderr, "[UPF-U][CONFIG] bad ports.core\n"); return -1; }
+            g_core_port = (int16_t)v;
+            g_sgi_port  = (int16_t)v;
+        }
+    }
+
+    return 0;
+}
+
+int UpfU_TryLoadAndParseConfig(const char *path) {
+    FILE *fp = fopen(path, "rb");
+    if (!fp) {
+        fprintf(stderr, "[UPF-U][CONFIG] cannot open config file: %s\n", path);
+        return -1;
+    }
+
+    yaml_parser_t parser;
+    yaml_document_t document;
+    if (!yaml_parser_initialize(&parser)) {
+        fclose(fp);
+        fprintf(stderr, "[UPF-U][CONFIG] yaml_parser_initialize failed\n");
+        return -1;
+    }
+    yaml_parser_set_input_file(&parser, fp);
+
+    // Load a full DOM (single-document expected)
+    if (!yaml_parser_load(&parser, &document)) {
+        yaml_parser_delete(&parser);
+        fclose(fp);
+        fprintf(stderr, "[UPF-U][CONFIG] yaml_parser_load failed (malformed YAML?)\n");
+        return -1;
+    }
+
+    int rc = do_parse(&document);
+
+    yaml_document_delete(&document);
+    yaml_parser_delete(&parser);
+    fclose(fp);
+
+    return rc == 0 ? 0 : -1;
+}
+
+void UpfU_LoadAndParseConfig(const char *path) {
+    if (UpfU_TryLoadAndParseConfig(path) != 0) {
+        fatal("Failed to load/parse UPF-U YAML config.");
+    }
+}

--- a/5gc/upf_u_complete/upf_u_config.h
+++ b/5gc/upf_u_complete/upf_u_config.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <stdint.h>
+
+
+void UpfU_LoadAndParseConfig(const char *path);
+
+int UpfU_TryLoadAndParseConfig(const char *path);


### PR DESCRIPTION
### Summary

Migrates UPF-U from the old `.txt` config to a structured `.yaml` config parsed via `libyaml`, with minimal impact on dataplane logic.

### Changes

- Add YAML config support for UPF-U (new `upf_u_config.c/.h`).
- Read `dn_mac`, `an_mac`, `upf_ip`, and `ports.{access,core}` from YAML.
- Meson: link `yaml-0.1` (libyaml) for `upf_u_complete`.

### Config location

- Place the config file at: 5gc/upf_u_complete/config/upf_u.yaml.

### Run command (updated)

```
./scripts/run/run_upf_u.sh 1 ./NFs/onvm-upf/5gc/upf_u_complete/config/upf_u.yaml
```

#### Notes

- No runtime behavior changes beyond reading values from YAML.
- SGI port continues to mirror CORE as before.