### PR TITLE
Issue 15: Remove the ARP filter in onvm_pkt.c

### DIFF
--- a/onvm/onvm_mgr/onvm_pkt.c
+++ b/onvm/onvm_mgr/onvm_pkt.c
@@ -80,16 +80,8 @@ onvm_pkt_process_rx_batch(struct queue_mgr *rx_mgr, struct rte_mbuf *pkts[], uin
                         meta->destination = onvm_sc_next_destination(sc, pkts[i], onvm_config->dynfield_offset);
                 } else {
 #endif
-                        eth_hdr = rte_pktmbuf_mtod(pkts[i], struct rte_ether_hdr *);
-                        ether_type = eth_hdr->ether_type;
-
-                        if (ether_type == rte_cpu_to_be_16(RTE_ETHER_TYPE_ARP)) {
-                                meta->action = ONVM_NF_ACTION_TONF;
-                                meta->destination = ARP_NF_ID;
-                        } else {
-                                meta->action = onvm_sc_next_action(default_chain, pkts[i], onvm_config->dynfield_offset);
-                                meta->destination = onvm_sc_next_destination(default_chain, pkts[i], onvm_config->dynfield_offset);
-                        }
+                        meta->action = onvm_sc_next_action(default_chain, pkts[i], onvm_config->dynfield_offset);
+                        meta->destination = onvm_sc_next_destination(default_chain, pkts[i], onvm_config->dynfield_offset);
 #ifdef FLOW_LOOKUP
                 }
 #endif


### PR DESCRIPTION
We configure the MAC addresses of UE/RAN node and DN node directly. The ARP filter is no longer being used. So, related codes have been removed.

Tested on Ubuntu 22.04