### PR TITLE
Remove legacy upf_u.txt config

### DIFF
--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -50,10 +50,6 @@
 #include "../classifiers/upf_cls_adapter.h"
 #include "../classifiers/classifier_wrapper.h"
 
-// for logging
-
-#include "upf_u_config.h"
-
 #include "upf_u_config.h"
 
 #define NF_TAG "upf_u"
@@ -112,7 +108,6 @@ int16_t g_core_port   = 0;
 int16_t g_sgi_port    = 0;
 
 
-
 struct rte_meter_trtcm_profile app_trtcm_profile;
 struct rte_meter_trtcm_profile app_flow_trtcm_profile;
 struct rte_meter_trtcm app_flows[APP_FLOWS_MAX];
@@ -135,6 +130,7 @@ struct flow_entry {
     int flow_idx;     // maps to trTCM flows table
     bool in_use;      // to track if the slot is occupied
 }typedef flow_entry_t;
+
 flow_entry_t iPFlows[APP_FLOWS_MAX];
 uint32_t iPFlowsLen = 0;
 uint32_t trTCMidx = 0;
@@ -397,7 +393,6 @@ ConfigureQerFlows(UpfSession *session,
     }
 }
 
-
 char *
 convertToIpAddress(uint32_t big_endian_value) {
     static char ip_string[16];
@@ -434,75 +429,6 @@ parseIpv4Address(const char *addrStr) {
     return 0;
 }
 
-void
-parseMAC(const char *config_path) {
-    FILE *file = fopen(config_path, "r");
-    if (file == NULL) {
-        fprintf(stderr, "Error: failed to open file %s\n", config_path);
-        exit(EXIT_FAILURE);
-    }
-
-    char line[256];
-    int linenum = 0;
-    int DNvalues[6];
-    int ANvalues[6];
-
-    while (fgets(line, sizeof(line), file) != NULL) {
-        linenum++;
-
-        char *p = line;
-        while (*p == ' ' || *p == '\t') p++;
-
-        if (strncmp(p, "ACCESS_PORT=", 12) == 0) {
-            int v = atoi(p + 12);
-            if (v >= 0 && v <= UINT8_MAX) g_access_port = (int16_t)v;
-            continue;
-        }
-        if (strncmp(p, "CORE_PORT=", 10) == 0) {
-            int v = atoi(p + 10);
-            if (v >= 0 && v <= UINT8_MAX) {
-                g_core_port = (int16_t)v;
-                g_sgi_port  = (int16_t)v;
-            }
-            continue;
-        }
-
-        if (linenum == 2) {
-            /* DN MAC Address */
-            if (sscanf(p, "%x:%x:%x:%x:%x:%x%*c",
-                       &DNvalues[0], &DNvalues[1], &DNvalues[2],
-                       &DNvalues[3], &DNvalues[4], &DNvalues[5]) == 6) {
-                for (int i = 0; i < 6; ++i) DnMac[i] = (uint8_t)DNvalues[i];
-            } else {
-                fprintf(stderr, "[Parse MAC] could not parse DN MAC from: %s", p);
-            }
-        }
-
-        if (linenum == 4) {
-            /* AN MAC Address */
-            if (sscanf(p, "%x:%x:%x:%x:%x:%x%*c",
-                       &ANvalues[0], &ANvalues[1], &ANvalues[2],
-                       &ANvalues[3], &ANvalues[4], &ANvalues[5]) == 6) {
-                for (int j = 0; j < 6; ++j) AnMac[j] = (uint8_t)ANvalues[j];
-            } else {
-                fprintf(stderr, "[Parse MAC] could not parse AN MAC from: %s", p);
-            }
-        }
-
-        if (linenum == 6) {
-            if (parseIpv4Address(p)) {
-                UTLT_Error("Parse IP address failed\n");
-            }
-        }
-    }
-
-    fclose(file);
-
-    UTLT_Debug("UPF port map (from upf_u.txt): ACCESS=%d CORE=%d SGI=%d",
-              g_access_port, g_core_port, g_sgi_port);
-}
-
-
 static inline source_interface_t PortToSourceInterface(uint8_t port) {
     if ((int)port == g_access_port)  return SRC_IF_ACCESS;
     if ((int)port == g_core_port)    return SRC_IF_CORE;
@@ -511,7 +437,6 @@ static inline source_interface_t PortToSourceInterface(uint8_t port) {
                  port, g_access_port, g_core_port, g_sgi_port);
     return SRC_IF_ACCESS;
 }
-
 
 static int
 trtcmConfigFlowTables(void){
@@ -663,8 +588,7 @@ initUeTable(){
 uint32_t 
 findIndexByUeIpAddress(uint32_t ue_ip) {
     int index = -1;
-    for (int i = 0; i < MAX_UE; i++)
-    {
+    for (int i = 0; i < MAX_UE; i++) {
         if (ue_table[i].ue_ip == ue_ip) {
             index = i;
         }
@@ -711,7 +635,7 @@ updateTokenbyIndex(int index) {
         uint64_t cur_cycles;
         uint64_t elapsed_cycles;
         uint64_t tokens_produced;
-        //
+
         cur_cycles = rte_get_tsc_cycles();
         elapsed_cycles = cur_cycles - ue_table[index].ue_nqos_tb_params.last_cycle;
 
@@ -1379,6 +1303,7 @@ msg_handler(void *msg_data, struct onvm_nf_local_ctx *nf_local_ctx) {
 }
 
 uint64_t last_p = NULL;
+
 static int 
 callback_handler(struct onvm_nf_local_ctx *nf_local_ctx) {
     if (unlikely(!last_p)) last_p = rte_get_tsc_cycles();
@@ -1446,16 +1371,13 @@ main(int argc, char *argv[]) {
     if (ret < 0)
         rte_exit(EXIT_FAILURE, "Cannot get MAC address: err=%d, port=%u\n", ret, 1);
 
-    // Parse DN & AN MAC address from upf_u.txt
-    //const char *config_path = "upf_u.txt";  // default
-
+    /* Parse DN & AN MAC address from config/upf_u.yaml */
     const char *config_path = "config/upf_u.yaml";
 
     if (argc > arg_offset + 1) {
         config_path = argv[arg_offset + 1];
     }
     printf("[UPF-U] Using config: %s\n", config_path);
-    //parseMAC(config_path);
     UpfU_LoadAndParseConfig(config_path);
 
     /* UTLT_Info("[UPF-U][CONFIG] Port map: ACCESS=%d CORE=%d SGI=%d",

--- a/5gc/upf_u/upf_u.txt
+++ b/5gc/upf_u/upf_u.txt
@@ -1,8 +1,0 @@
-# DN MAC Address
-3c:fd:fe:b0:f1:f4
-# AN MAC Address
-3c:fd:fe:b0:f5:4d
-# UPF ID Address
-192.168.1.2
-ACCESS_PORT=1
-CORE_PORT=0

--- a/tools/Pktgen/README.md
+++ b/tools/Pktgen/README.md
@@ -18,6 +18,7 @@ For further information regarding Pktgen configuration or set up, please refer t
   - [2.2 Build Pktgen Application](#22-build-pktgen-application)
   - [2.3 Configure Pktgen for openNetVM](#23-configure-pktgen-for-opennetvm)
   - [2.4 Run pktgen](#24-run-pktgen)
+  - [2.5 Enable and Replay PCAP Files in Pktgen](#25-enable-and-replay-pcap-files-in-pktgen)
 - [3 Editing GTP-U PCAP Files](#3-editing-gtp-u-pcap-files)
   - [3.1 Install Dependencies](#31-install-dependencies)
   - [3.2 Script Overview](#32-script-overview)
@@ -297,6 +298,60 @@ Src MAC Address :  90:e2:ba:5a:f7:90  90:e2:ba:5a:f7:91
 Run `start all` to start sending packets.  
 
 Please use `pktgen> exit` for existing. 
+
+
+2.5 Enable and Replay PCAP Files in Pktgen
+------------- 
+Pktgen supports replaying PCAP files on a specified port. After launching Pktgen using your configuration file, follow the steps below to enable PCAP mode and replay the file.
+
+These examples assume **port 0** is used for PCAP replay (as configured in the sample `cfg` file).
+
+### Step 1: Enable PCAP mode on port 0
+
+At the Pktgen command prompt:
+
+```
+pktgen> enable 0 pcap
+```
+
+This instructs Pktgen to use the PCAP file specified in your configuration for port 0.
+
+---
+
+### Step 2: Start the PCAP replay
+
+Start sending packets from the PCAP:
+
+```
+pktgen> start 0
+```
+
+Pktgen will begin replaying the packets in a continuous loop unless a transmit count limit is configured.
+
+---
+
+### Step 3: Adjust the packet transmission rate (optional)
+
+You may dynamically change the send rate using:
+
+```
+pktgen> set 0 rate 0.001
+```
+
+This sets the transmit rate for port 0 to **0.001%** of the link speed.
+You can adjust the value to increase or decrease the traffic load.
+
+---
+
+### Notes
+
+* If your PCAP file contains GTP-U traffic, you can use the `gtpu_editor.py` script in Section 3 to preprocess or rewrite the PCAP before replaying.
+* Rate control (`set <port> rate <value>`) can be applied at any time during replay.
+* You can stop replay using:
+
+  ```
+  pktgen> stop 0
+  ```
 
 ---
 


### PR DESCRIPTION
This PR removes the deprecated `upf_u.txt` configuration file and updates the UPF-U logic to use the new YAML-based configuration located under `5gc/upf_u/config/`. The codebase no longer relies on the old text-based config format.

### **Motivation**

* The project has standardized on YAML configuration for all UPF components.
* The old `.txt` config file was unused and misleading.
* The parsing code still contained references to the legacy file format.

### **What’s Changed**

* Removed `5gc/upf_u/upf_u.txt`
* Updated configuration parsing logic in `upf_u.c`:

  * Eliminated dead code branches referencing the `.txt` file
  * Cleaned up conditional logic related to legacy format
  * Ensured YAML config loading is the only active path

### **Impact**

* No functional change to UPF-U behavior
* Reduces technical debt
* Avoids potential confusion for new developers
* Prepares the codebase for future extensions of the YAML config schema

### **Testing**

* UPF-U compiled successfully after removal
* Verified that UPF-U loads and parses `config/upf_u.yaml` without issues
* Sanity-tested startup workflow under ONVM runtime
