### PR TITLE
Separate mbuf pools for user-plane and control-plane traffic in L25GC+

### DIFF
--- a/onvm/onvm_mgr/onvm_init.c
+++ b/onvm/onvm_mgr/onvm_init.c
@@ -60,6 +60,7 @@ struct onvm_configuration *onvm_config = NULL;
 struct nf_wakeup_info *nf_wakeup_infos = NULL;
 
 struct rte_mempool *pktmbuf_pool;
+struct rte_mempool *cp_pktmbuf_pool;
 struct rte_mempool *nf_init_cfg_pool;
 struct rte_mempool *nf_msg_pool;
 struct rte_ring *incoming_msg_queue;
@@ -296,7 +297,7 @@ set_default_config(struct onvm_configuration *config) {
 
 /**
  * Initialise the mbuf pool for packet reception for the NIC, and any other
- * buffer pools needed by the app - currently none.
+ * buffer pools needed by the app - currently L25GC+ control plane SBI.
  */
 static int
 init_mbuf_pools(void) {
@@ -312,6 +313,11 @@ init_mbuf_pools(void) {
         printf("Creating mbuf pool '%s' [%u mbufs] ...\n", PKTMBUF_POOL_NAME, NUM_MBUFS);
         /* NOTE: override MBUF_SIZE */
         pktmbuf_pool = rte_mempool_create(PKTMBUF_POOL_NAME, NUM_MBUFS, MBUF_SIZE, MBUF_CACHE_SIZE,
+                                          sizeof(struct rte_pktmbuf_pool_private), rte_pktmbuf_pool_init, NULL,
+                                          rte_pktmbuf_init, NULL, rte_socket_id(), NO_FLAGS);
+
+        printf("Creating L25GC+ control plane SBI mbuf pool '%s' [%u mbufs] ...\n", CP_PKTMBUF_POOL_NAME, NUM_MBUFS);
+        cp_pktmbuf_pool = rte_mempool_create(CP_PKTMBUF_POOL_NAME, NUM_MBUFS, MBUF_SIZE, MBUF_CACHE_SIZE,
                                           sizeof(struct rte_pktmbuf_pool_private), rte_pktmbuf_pool_init, NULL,
                                           rte_pktmbuf_init, NULL, rte_socket_id(), NO_FLAGS);
 

--- a/onvm/onvm_mgr/onvm_init.h
+++ b/onvm/onvm_mgr/onvm_init.h
@@ -109,6 +109,7 @@ extern struct port_info *ports;
 extern struct core_status *cores;
 
 extern struct rte_mempool *pktmbuf_pool;
+extern struct rte_mempool *cp_pktmbuf_pool;
 extern struct rte_mempool *nf_msg_pool;
 extern uint16_t num_nfs;
 extern uint16_t num_services;

--- a/onvm/onvm_nflib/onvm_common.h
+++ b/onvm/onvm_nflib/onvm_common.h
@@ -388,6 +388,7 @@ struct ft_request {
 #define MP_NF_TXQ_NAME "MProc_Client_%u_TX"
 #define MP_CLIENT_SEM_NAME "MProc_Client_%u_SEM"
 #define PKTMBUF_POOL_NAME "MProc_pktmbuf_pool"
+#define CP_PKTMBUF_POOL_NAME "CP_MProc_pktmbuf_pool"
 #define MZ_PORT_INFO "MProc_port_info"
 #define MZ_CORES_STATUS "MProc_cores_info"
 #define MZ_NF_INFO "MProc_nf_init_cfg"

--- a/onvm/pfcp/pfcp_path.c
+++ b/onvm/pfcp/pfcp_path.c
@@ -95,7 +95,7 @@ Status PfcpSend(PfcpNode *node, Bufblk *bufBlk) {
     uint32_t i;
     struct rte_mempool *pktmbuf_pool;
 
-    pktmbuf_pool = rte_mempool_lookup(PKTMBUF_POOL_NAME);
+    pktmbuf_pool = rte_mempool_lookup(CP_PKTMBUF_POOL_NAME);
     if (pktmbuf_pool == NULL) {
         return STATUS_ERROR;
     }


### PR DESCRIPTION
This is a fix for Issue: #35.

[Click here](https://github.com/nycu-ucr/onvm-upf/issues/35) for more details on the issue itself, resolution plans and acceptance criteria. 


NB: This feature has been tested with Ubuntu 22.04 on Cloudlab with both c220g5 and c220g2 clusters.