### PR TITLE
Optimize UTLT logging fast-path and fix GTP-U header parsing inconsistency

### DIFF
--- a/onvm/upf/gtp.h
+++ b/onvm/upf/gtp.h
@@ -364,8 +364,12 @@ static inline uint16_t get_gtpu_header_len_with_qfi(struct rte_mbuf *pkt, uint8_
 
     uint16_t gtp_len = sizeof(gtpv1_t);
 
-    gtpv1_t *gtpv1 = rte_pktmbuf_mtod_offset(pkt, gtpv1_t *,
-                                             sizeof(struct rte_ipv4_hdr) + sizeof(struct rte_udp_hdr));
+    gtpv1_t *gtpv1 = rte_pktmbuf_mtod_offset(pkt, gtpv1_t *, 
+      sizeof(struct rte_ether_hdr) + 
+      sizeof(struct rte_ipv4_hdr) + 
+      sizeof(struct rte_udp_hdr)
+    );
+
 
     if (gtpv1->flags & GTP1_F_MASK) {
         gtp_len += 4;
@@ -377,17 +381,27 @@ static inline uint16_t get_gtpu_header_len_with_qfi(struct rte_mbuf *pkt, uint8_
         uint8_t next_ehdr_type = 0;
         gtpv1_hdr_opt_t *gtpv1_opt;
 
-        gtpv1_opt = rte_pktmbuf_mtod_offset(pkt, gtpv1_hdr_opt_t *,
-                            sizeof(struct rte_ipv4_hdr) + sizeof(struct rte_udp_hdr) + sizeof(gtpv1_t));
+        gtpv1_opt = rte_pktmbuf_mtod_offset(pkt, gtpv1_hdr_opt_t *, 
+          sizeof(struct rte_ether_hdr) + 
+          sizeof(struct rte_ipv4_hdr) + 
+          sizeof(struct rte_udp_hdr) + 
+          sizeof(gtpv1_t)
+        );
+
         next_ehdr_type = gtpv1_opt->next_ehdr_type;
 
         while (next_ehdr_type) {
             switch (next_ehdr_type) {
             case GTPV1_NEXT_EXT_HDR_TYPE_85: {
-                pdu_sess_container_hdr_t *ehdr_type_85 =
-                    rte_pktmbuf_mtod_offset(pkt, pdu_sess_container_hdr_t *,
-                        sizeof(struct rte_ipv4_hdr) + sizeof(struct rte_udp_hdr) +
-                        sizeof(gtpv1_t) + sizeof(gtpv1_hdr_opt_t));
+    
+                pdu_sess_container_hdr_t *ehdr_type_85 = 
+                rte_pktmbuf_mtod_offset(pkt, pdu_sess_container_hdr_t *, 
+                  sizeof(struct rte_ether_hdr) + 
+                  sizeof(struct rte_ipv4_hdr) + 
+                  sizeof(struct rte_udp_hdr) + 
+                  sizeof(gtpv1_t) + 
+                  sizeof(gtpv1_hdr_opt_t)
+                );
 
                 // Extract QFI (first payload byte after fixed fields)
                 uint8_t *raw = (uint8_t *)ehdr_type_85;

--- a/onvm/utlt/utlt_debug.c
+++ b/onvm/utlt/utlt_debug.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
+#include <strings.h>
 #include <stdarg.h>
 
 #include "logger.h"
@@ -12,8 +13,29 @@
 #define MAX_SIZE_OF_BUFFER 32768
 
 unsigned int reportCaller = 0;
+/* Fast-path log filter (avoids formatting when message would be dropped).
+ * Default = most verbose to preserve historical behavior until UTLT_SetLogLevel is called. */
+static int g_utlt_min_level = LOG_TRACE;
+
+static inline int
+utlt_parse_level(const char *level) {
+    if (level == NULL) return -1;
+    if (strcasecmp(level, "panic") == 0)   return LOG_PANIC;
+    if (strcasecmp(level, "fatal") == 0)   return LOG_FATAL;
+    if (strcasecmp(level, "error") == 0)   return LOG_ERROR;
+    if (strcasecmp(level, "warning") == 0) return LOG_WARNING;
+    if (strcasecmp(level, "warn") == 0)    return LOG_WARNING;
+    if (strcasecmp(level, "info") == 0)    return LOG_INFO;
+    if (strcasecmp(level, "debug") == 0)   return LOG_DEBUG;
+    if (strcasecmp(level, "trace") == 0)   return LOG_TRACE;
+    return -1;
+}
 
 Status UTLT_SetLogLevel(const char *level) {
+    int parsed = utlt_parse_level(level);
+    if (parsed >= 0) {
+        __atomic_store_n(&g_utlt_min_level, parsed, __ATOMIC_RELEASE);
+    }
     if (UpfUtilLog_SetLogLevel(UTLT_CStr2GoStr(level)))
         return STATUS_OK;
     else
@@ -33,6 +55,11 @@ Status UTLT_SetReportCaller(unsigned int flag) {
 int UTLT_LogPrint(int level, const char *filename, const int line, 
                   const char *funcname, const char *fmt, ...) {
     static char buffer[MAX_SIZE_OF_BUFFER];
+
+    const int min_level = __atomic_load_n(&g_utlt_min_level, __ATOMIC_ACQUIRE);
+    if (level > min_level) {
+        return STATUS_OK;
+    }
 
     unsigned int cnt = 0, vspCnt = 0;
     if (reportCaller == REPORTCALLER_TRUE) {


### PR DESCRIPTION
This PR addresses two things:

1. Logging: filter-before-format
2. GTP-U parsing: align offsets with Ethernet

- ### Reduce logging overhead

Originally, UTLT logging path was “filter late”. The code would eagerly build the final log string with `snprintf/vsnprintf`, then call into the Go logger (`UpfUtilLog_*`). If the Go side decided the message’s level was below the current log level, it would drop it — but the expensive work (formatting) already happened. It didn't matter whether we had opted logging level `info/warning/error` in `upf_u.c`.

We added a C-side minimum log level (`g_utlt_min_level`) and check it before any formatting. If the message is to be dropped, `UTLT_LogPrint()` exits before `vsnprintf`. This early-exit happens before any formatting and before calling into the Go logger.


- ### Correct GTP-U QFI header offsets

In the UPF dataplane code path `get_gtpu_header_len_with_qfi()` was being called on packets that still had the Ethernet header present. However, it previously assumed that it received `IPv4 + UDP + GTP`. That meant the function would read the wrong bytes for GTP flags/extension headers and compute the wrong inner-payload offset/QFI.

Now we parse the packets assuming the layout `Ethernet + IPv4 + UDP + GTP`. This aligns `get_gtpu_header_len_with_qfi()` with `parse_gtp_packet()/get_teid_gtp_packet()`, so all GTP helpers assume the same packet layout (Ethernet included).

