### PR TITLE
Disable DPDK NIC binding check when launching ONVM manager

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -224,12 +224,12 @@ ports_bin="${ports_bin//0/}"
 # The number of ports is the length of the string of 1's. Using above example: 1111 -> 4
 count_ports="${#ports_bin}"
 
-ports_detected=$(subprojects/dpdk/usertools/dpdk-devbind.py --status-dev net | sed '/Network devices using kernel driver/q' | grep -c "drv")
-if [[ $ports_detected -lt $count_ports ]]
-then
-    echo "Error: Invalid port mask. Insufficient NICs bound."
-    exit 1
-fi
+#ports_detected=$(subprojects/dpdk/usertools/dpdk-devbind.py --status-dev net | sed '/Network devices using kernel driver/q' | grep -c "drv")
+#if [[ $ports_detected -lt $count_ports ]]
+#then
+#    echo "Error: Invalid port mask. Insufficient NICs bound."
+#    exit 1
+#fi
 
 # Trim 0x from NF mask
 nf_cores_trimmed=${nf_cores:2}


### PR DESCRIPTION
### Summary

This PR disables the port detection / NIC binding validation step in the ONVM manager startup script. The previous logic relied on `dpdk-devbind.py --status-dev net` to verify that a sufficient number of NICs are “bound” before starting `onvm_mgr`. On Mellanox-based deployments (e.g., NSF FABRIC), this check can be misleading and cause false failures even when the NICs are usable.

### What changed

* Commented out the `ports_detected` check that:

  * counts NICs reported by `dpdk-devbind.py`
  * compares them against the portmask-derived expected count
  * exits with an error if fewer devices appear “bound”

### Why

* Mellanox NICs (and some FABRIC environments) do not always follow the same binding expectations as other DPDK setups.
* The existing check can incorrectly block `onvm_mgr` startup with:

  * `Error: Invalid port mask. Insufficient NICs bound.`
* We still rely on:

  * correct portmask configuration, and
  * (when needed) PCI whitelisting via `-w <PCI_ADDR>`
    to ensure the intended ports are used.

### Testing

* Manually verified that `onvm_mgr` starts successfully after this change on a Mellanox-based environment where the previous binding check failed.

### Notes / Follow-ups

* We may consider gating this check behind a flag (e.g., `SKIP_PORT_DETECT=1`) in the future, but for now it is disabled to improve robustness on Mellanox/FABRIC deployments.
