### PR TITLE
UPF-U fastpath: single-pass GTP-U parse + PDR-local QER selection for UE QoS table

### DIFF
--- a/5gc/upf_c/n4_onvm_pfcp_handler.c
+++ b/5gc/upf_c/n4_onvm_pfcp_handler.c
@@ -593,8 +593,19 @@ Status UpfN4HandleCreatePdr(UpfSession *session, CreatePDR *createPdr) {
         //     upfPdr->qer = UpfQERFindByID(s1, upfPdr->qerId);
         //     UTLT_Assert(upfPdr->qer, rte_free(upfPdr); return STATUS_ERROR, "QER ID[%u] does NOT exist in UPF Context", upfPdr->qerId);
         // }
-        upfPdr->qer = UpfQERFindByID(session, upfPdr->qerId[0]);
-        UTLT_Assert(upfPdr->qer, rte_free(upfPdr); return STATUS_ERROR, "QER ID[%u] does NOT exist in UPF Context", upfPdr->qerId[0]);
+        upfPdr->qer_count = 0;
+        upfPdr->qers[0] = upfPdr->qers[1] = NULL;
+
+        for (int i = 0; i < 2; i++) {
+            uint32_t id = upfPdr->qerId[i];
+            if (!id) continue;
+
+            UpfQER *q = UpfQERFindByID(session, id);
+            UTLT_Assert(q, rte_free(upfPdr); return STATUS_ERROR, "QER ID[%u] does NOT exist in UPF Context", id);
+
+            upfPdr->qers[upfPdr->qer_count++] = q;   // packed list
+        }
+        upfPdr->qer = (upfPdr->qer_count > 0) ? upfPdr->qers[0] : NULL;
     }
 
     // Register PDR to Session
@@ -1031,15 +1042,33 @@ Status _ConvertUpdatePDRTlvToRule(UpfPDR *upfPdr, UpdatePDR *updatePDR) {
         }
     }
 
+    // if (updatePDR->qERID.presence) {
+    //     // TODO: Need to handle multiple QER
+    //     /*
+    //         upfPdr->flags.qerId = 1;
+    //     upfPdr->qerId = ntohl(*((uint32_t *)updatePDR->qERID.value));
+    //     UTLT_Debug("PDR QER ID: %u", upfPdr->qerId);
+    //     */
+    //     UTLT_Warning("UPF do NOT support QER yet");
+    // }
+
+
     if (updatePDR->qERID.presence) {
-        // TODO: Need to handle multiple QER
-        /*
-            upfPdr->flags.qerId = 1;
-        upfPdr->qerId = ntohl(*((uint32_t *)updatePDR->qERID.value));
-        UTLT_Debug("PDR QER ID: %u", upfPdr->qerId);
-        */
-        UTLT_Warning("UPF do NOT support QER yet");
+        upfPdr->flags.qerId = 1;
+        uint32_t new_id = ntohl(*((uint32_t *)updatePDR->qERID.value));
+
+        if (upfPdr->qerId[0] == new_id || upfPdr->qerId[1] == new_id) {
+            /* already associated -> no change */
+        } else if (upfPdr->qerId[0] == 0) {
+            upfPdr->qerId[0] = new_id;
+        } else if (upfPdr->qerId[1] == 0) {
+            upfPdr->qerId[1] = new_id;
+        } else {
+            UTLT_Warning("UpdatePDR: ignore QERID=%u; PDR[%u] already has QERIDs (%u,%u)",
+                        new_id, upfPdr->pdrId, upfPdr->qerId[0], upfPdr->qerId[1]);
+        }
     }
+
 
     if (updatePDR->activatePredefinedRules.presence) {
         // TODO: Need to support
@@ -1073,8 +1102,25 @@ Status UpfN4HandleUpdatePdr(UpfSession *session, UpdatePDR *updatePdr) {
     }
 
     if (upfPdr->flags.qerId) {
-        upfPdr->qer = UpfQERFindByID(session, upfPdr->qerId[0]);
-        UTLT_Assert(upfPdr->qer, return STATUS_ERROR, "QER ID[%u] does NOT exist in UPF Context", upfPdr->qerId[0]);
+        UpfQER  *new_qers[2] = { NULL, NULL };
+        uint8_t  new_cnt = 0;
+
+        for (int i = 0; i < 2; i++) {
+            uint32_t id = upfPdr->qerId[i];
+            if (!id) continue;
+
+            UpfQER *q = UpfQERFindByID(session, id);
+            UTLT_Assert(q, return STATUS_ERROR,
+                    "QER ID[%u] does NOT exist in UPF Context", id);
+
+            if (new_cnt < 2) new_qers[new_cnt++] = q;  // packed list
+        }
+
+        /* Commit only after all lookups succeeded */
+        upfPdr->qers[0] = new_qers[0];
+        upfPdr->qers[1] = new_qers[1];
+        upfPdr->qer_count = new_cnt;
+        upfPdr->qer = (new_cnt > 0) ? new_qers[0] : NULL; // legacy
     }
 
 #ifdef CHECK

--- a/5gc/upf_c/n4_onvm_pfcp_handler.c
+++ b/5gc/upf_c/n4_onvm_pfcp_handler.c
@@ -1072,6 +1072,11 @@ Status UpfN4HandleUpdatePdr(UpfSession *session, UpdatePDR *updatePdr) {
         UTLT_Assert(upfPdr->far, return STATUS_ERROR, "FAR ID[%u] does NOT exist in UPF Context", upfPdr->farId);
     }
 
+    if (upfPdr->flags.qerId) {
+        upfPdr->qer = UpfQERFindByID(session, upfPdr->qerId[0]);
+        UTLT_Assert(upfPdr->qer, return STATUS_ERROR, "QER ID[%u] does NOT exist in UPF Context", upfPdr->qerId[0]);
+    }
+
 #ifdef CHECK
     // Register PDR to Session
     UTLT_Assert(UpfPDRRegisterToSession(session, &upfPdr),

--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -1130,11 +1130,11 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
     UTLT_Info("Got PDR ID is %u\n", pdr->pdrId);
 
     if (is_dl) {
+        uint32_t ue_key = rte_cpu_to_be_32(iph->dst_addr);
         ue_idx = (int)findIndexByUeIpAddress(ue_key);
         if (ue_idx < 0) {
-            ue_idx = GetQerByUEIpAddressFromPdr(rte_cpu_to_be_32(iph->dst_addr), pdr, convertToIpAddress(iph->dst_addr));
+            ue_idx = GetQerByUEIpAddressFromPdr(ue_key, pdr, convertToIpAddress(iph->dst_addr));
         }
-        
     }
 
     rte_pktmbuf_adj(pkt, sizeof(struct rte_ether_hdr));

--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -597,37 +597,36 @@ findIndexByUeIpAddress(uint32_t ue_ip) {
     return index;
 }
 
-void
-addEntrybyUeIp(uint32_t ue_ip, uint32_t ue_ambr, uint32_t ue_gbr,uint32_t ue_mbr) {
+int
+addEntrybyUeIp(uint32_t ue_ip, uint32_t ue_ambr, uint32_t ue_gbr, uint32_t ue_mbr) {
     for (int i = 0; i < MAX_UE; i++) {
         if (ue_table[i].ue_ip == 0) { // find unused
             ue_table[i].ue_ip = ue_ip;
             ue_table[i].ue_ambr = ue_ambr;
             ue_table[i].ue_gbr = ue_gbr;
 
-            uint32_t qos_rate = MIN((ue_gbr + (ue_ambr-ue_gbr)/2), ue_mbr);
+            uint32_t qos_rate = MIN((ue_gbr + (ue_ambr - ue_gbr) / 2), ue_mbr);
 
-            ue_table[i].ue_qos_tb_params.tb_rate = qos_rate/1000;
+            ue_table[i].ue_qos_tb_params.tb_rate = qos_rate / 1000;
             ue_table[i].ue_qos_tb_params.tb_depth = qos_rate;
             ue_table[i].ue_qos_tb_params.tb_tokens = qos_rate;
             ue_table[i].ue_qos_tb_params.last_cycle = rte_get_tsc_cycles();
-            ue_table[i].ue_qos_tb_params.cur_cycles = rte_get_tsc_cycles(); 
+            ue_table[i].ue_qos_tb_params.cur_cycles = rte_get_tsc_cycles();
             UTLT_Info("QoS Rate: %d", qos_rate);
 
             uint32_t nqos_rate = ue_ambr - qos_rate;
 
-            ue_table[i].ue_nqos_tb_params.tb_rate = nqos_rate/1000;
+            ue_table[i].ue_nqos_tb_params.tb_rate = nqos_rate / 1000;
             ue_table[i].ue_nqos_tb_params.tb_depth = nqos_rate;
             ue_table[i].ue_nqos_tb_params.tb_tokens = nqos_rate;
             ue_table[i].ue_nqos_tb_params.last_cycle = rte_get_tsc_cycles();
             ue_table[i].ue_nqos_tb_params.cur_cycles = rte_get_tsc_cycles();
-            UTLT_Info("non QoS Rate: %d", nqos_rate); 
+            UTLT_Info("non QoS Rate: %d", nqos_rate);
 
-
-            break;
+            return i;  // Return the allocated index
         }
     }
-    return;
+    return -1;  // Table full
 }
 
 void 
@@ -887,48 +886,54 @@ GetQerByUEIpAddress(uint32_t ue_ip, char *IP) {
     }
 }
 
-/* Populate UE table using the already-classified UPDK_PDR (no session/pdr_list scan).
- * DL-only: uses qer->*.dl fields.
- * Returns NULL to match the old function style. */
-static inline void *
+/* Populate UE table using the already-classified UPDK_PDR (no session/pdr_list scan)*/
+static inline int
 GetQerByUEIpAddressFromPdr(uint32_t ue_ip, const UPDK_PDR *pdr, const char *ip_str)
 {
-    if ((int)findIndexByUeIpAddress(ue_ip) != -1) {
-        UTLT_Trace("The UE IP already exists in the table");
-        return NULL;
-    }
-
-    if (!pdr || !pdr->qer) {
-        UTLT_Warning("UE %s: no PDR/QER, cannot populate UE table",
-                     ip_str ? ip_str : "<unknown>");
-        return NULL;
-    }
-
-    const UPDK_QER *qer = pdr->qer;
-
-    /* Respect presence; avoid using uninitialized values */
-    if (!qer->flags.maximumBitrate || qer->maximumBitrate.dl == 0) {
-        UTLT_Trace("UE %s: no DL MBR, skip UE table entry",
+    if (!pdr || pdr->qer_count == 0) {
+        UTLT_Trace("UE %s: No PDR or PDR has no QERs, skip UE table entry",
                    ip_str ? ip_str : "<unknown>");
-        return NULL;
+        return -1;
     }
 
-    /* Clamp 64-bit PFCP rates into 32-bit UE table fields */
-    uint64_t mbr64  = qer->maximumBitrate.dl;
-    uint64_t gbr64  = qer->flags.guaranteedBitrate ? qer->guaranteedBitrate.dl : 0;
+    uint64_t ambr64 = 0;
+    uint64_t gbr64  = 0;
+    uint64_t mbr64  = 0;
 
-    uint32_t mbr  = (mbr64 > UINT32_MAX) ? UINT32_MAX : (uint32_t)mbr64;
-    uint32_t ambr = mbr;  /* with only one PDR/QER, AMBR ~= MBR */
-    uint32_t gbr  = (gbr64 > UINT32_MAX) ? UINT32_MAX : (uint32_t)gbr64;
+    int n = (int)pdr->qer_count;
+    if (n > 2) n = 2; /* safety; struct currently supports 2 */
 
-    /* Prevent unsigned underflow in addEntrybyUeIp() math if CP gives weird values */
-    if (gbr > mbr) gbr = mbr;
+    for (int i = 0; i < n; i++) {
+        const UPDK_QER *q = pdr->qers[i];
+        if (!q) continue;
+
+        if (q->flags.maximumBitrate && q->maximumBitrate.dl > ambr64)
+            ambr64 = q->maximumBitrate.dl;
+
+        /* old behavior: only set gbr/mbr when both flags are present */
+        if (q->flags.guaranteedBitrate && q->flags.maximumBitrate) {
+            gbr64 = q->guaranteedBitrate.dl;
+            mbr64 = q->maximumBitrate.dl;
+        }
+    }
+
+    if (ambr64 == 0) {
+        UTLT_Trace("UE %s: no DL MBR across PDR QERs, skip UE table entry",
+                   ip_str ? ip_str : "<unknown>");
+        return -1;
+    }
+
+    /* Clamp PFCP 64-bit rates into 32-bit UE table fields */
+    uint32_t ambr = (ambr64 > UINT32_MAX) ? UINT32_MAX : (uint32_t)ambr64;
+    uint32_t gbr  = (gbr64  > UINT32_MAX) ? UINT32_MAX : (uint32_t)gbr64;
+    uint32_t mbr  = (mbr64  > UINT32_MAX) ? UINT32_MAX : (uint32_t)mbr64;
+
+    if (mbr && gbr > mbr) gbr = mbr;
 
     UTLT_Warning("Add UE IP: %s, AMBR: %u GBR: %u, MBR: %u",
                  ip_str ? ip_str : "<unknown>", ambr, gbr, mbr);
 
-    addEntrybyUeIp(ue_ip, ambr, gbr, mbr);
-    return NULL;
+    return addEntrybyUeIp(ue_ip, ambr, gbr, mbr);
 }
 
 
@@ -1091,6 +1096,7 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
 
     UPDK_PDR *pdr = NULL;
     gtp_parse_result_t gtp_info = {0};
+    int ue_idx = -1;
 
     /* char *src_address = convertToIpAddress(iph->src_addr);
     UTLT_Info("Src IP is %s\n", src_address);
@@ -1124,7 +1130,11 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
     UTLT_Info("Got PDR ID is %u\n", pdr->pdrId);
 
     if (is_dl) {
-        GetQerByUEIpAddressFromPdr(rte_cpu_to_be_32(iph->dst_addr), pdr, convertToIpAddress(iph->dst_addr));
+        ue_idx = (int)findIndexByUeIpAddress(ue_key);
+        if (ue_idx < 0) {
+            ue_idx = GetQerByUEIpAddressFromPdr(rte_cpu_to_be_32(iph->dst_addr), pdr, convertToIpAddress(iph->dst_addr));
+        }
+        
     }
 
     rte_pktmbuf_adj(pkt, sizeof(struct rte_ether_hdr));
@@ -1166,13 +1176,8 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
     }
     AttachL2Header(pkt, is_dl);
     if (meta->action == ONVM_NF_ACTION_OUT && is_dl) {
-        // check if the UE IP exists in the table and update the token
-        int index = findIndexByUeIpAddress(rte_cpu_to_be_32(iph->dst_addr));
-        if (index != -1) {
-            UTLT_Trace("Update token for UE IP: %s", convertToIpAddress(iph->dst_addr));
-            updateTokenbyIndex(index);
-        }
-        else {
+
+        if (ue_idx < 0) {
             UTLT_Error("No UE IP found in the table");
             return status;
         }
@@ -1208,25 +1213,25 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
                 meta->action = ONVM_NF_ACTION_DROP;
             }
             if (meta->flags == RTE_COLOR_GREEN) {
-                ue_table[index].ue_qos_tb_params.tb_tokens -= cal_pktlen;
+                ue_table[ue_idx].ue_qos_tb_params.tb_tokens -= cal_pktlen;
                 meta->action = ONVM_NF_ACTION_OUT;
             }
             if (meta->flags == RTE_COLOR_YELLOW) {
-                while (ue_table[index].ue_qos_tb_params.tb_tokens < cal_pktlen) {
-                    updateTokenbyIndex(index);
+                while (ue_table[ue_idx].ue_qos_tb_params.tb_tokens < cal_pktlen) {
+                    updateTokenbyIndex(ue_idx);
                     usleep(1);
                 }
-                ue_table[index].ue_qos_tb_params.tb_tokens -= cal_pktlen;
+                ue_table[ue_idx].ue_qos_tb_params.tb_tokens -= cal_pktlen;
                 meta->action = ONVM_NF_ACTION_OUT;      
             }
         }
         // Step 2. bucket (non QoS flow)
         else {
-            while (ue_table[index].ue_nqos_tb_params.tb_tokens < cal_pktlen) {
-                updateTokenbyIndex(index);
+            while (ue_table[ue_idx].ue_nqos_tb_params.tb_tokens < cal_pktlen) {
+                updateTokenbyIndex(ue_idx);
                 usleep(1);
             }
-            ue_table[index].ue_nqos_tb_params.tb_tokens -= cal_pktlen;
+            ue_table[ue_idx].ue_nqos_tb_params.tb_tokens -= cal_pktlen;
             meta->action = ONVM_NF_ACTION_OUT;
         }
     }

--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -591,6 +591,7 @@ findIndexByUeIpAddress(uint32_t ue_ip) {
     for (int i = 0; i < MAX_UE; i++) {
         if (ue_table[i].ue_ip == ue_ip) {
             index = i;
+            break;
         }
     }
     return index;
@@ -759,86 +760,26 @@ static void dump_gtpu(const uint8_t *start, size_t len, size_t gtp_off) {
     printf("\n------------------------------------------\n");
 }
 
-UPDK_PDR *GetPdrByTeid(struct rte_mbuf *pkt, uint32_t td) {
-    char o_src[16], o_dst[16], i_src[16], i_dst[16], ue_s[16], dn_s[16];
+UPDK_PDR *GetPdrByTeid(struct rte_mbuf *pkt, const gtp_parse_result_t *gtp_info) {
+        // Locate inner IP header using pre-computed offset
+    size_t inner_offset = sizeof(struct rte_ether_hdr) + gtp_info->outer_hdr_len;
+
     uint16_t data_len = rte_pktmbuf_data_len(pkt);
+    if (data_len < inner_offset + sizeof(struct rte_ipv4_hdr)) return NULL;
 
-    // Outer IPv4
-    struct rte_ipv4_hdr *outer4 = onvm_pkt_ipv4_hdr(pkt);
-    if (!outer4) return NULL;
-    UTLT_Debug("Outer IPv4 src=%s dst=%s totlen=%u",
-               ip4_to_buf(outer4->src_addr, o_src),
-               ip4_to_buf(outer4->dst_addr, o_dst),
-               data_len);
+    struct rte_ipv4_hdr *inner4 = rte_pktmbuf_mtod_offset(pkt, struct rte_ipv4_hdr *, inner_offset);
 
-    // Outer UDP
-    struct rte_udp_hdr *outerU = onvm_pkt_udp_hdr(pkt);
-    if (!outerU) return NULL;
-    if (outerU->dst_port != rte_cpu_to_be_16(2152)) return NULL;
+    // Verify it looks like IPv4
+    if ((inner4->version_ihl >> 4) != 4) return NULL;
 
-    // TEID extraction
-    uint32_t teid = get_teid_gtp_packet(pkt, outerU);
-    UTLT_Debug("Extracted TEID (host order): %u", teid);
-
-    // GTP-U header length + QFI
-    uint8_t qfi = 0;
-    uint16_t payload_offset = get_gtpu_header_len_with_qfi(pkt, &qfi);
-    UTLT_Debug("Computed GTP-U payload_offset=%u QFI=%u", payload_offset, qfi);
-
-    // Base pointer to GTP header
-    uint8_t *base = rte_pktmbuf_mtod(pkt, uint8_t *) +
-                    sizeof(struct rte_ether_hdr) +
-                    ((outer4->version_ihl & 0x0F) * 4) +
-                    sizeof(*outerU);
-
-    // Dump for verification
-    size_t dbg_len = (data_len > 64) ? 64 : data_len;
-    // dump_gtpu(base, dbg_len, (size_t)(base - rte_pktmbuf_mtod(pkt, uint8_t *)));
-
-    // Fallback: verify payload start looks like IPv4, else scan nearby
-    uint8_t *inner_ptr = base + payload_offset;
-
-    if ((inner_ptr[0] >> 4) != 4 || (inner_ptr[0] & 0x0F) < 5) {
-        UTLT_Info("Non-IPv4 start at offset %u (0x%02x), scanning for IPv4...",
-                     payload_offset, inner_ptr[0]);
-        int found = 0;
-        for (int delta = -4; delta <= 4; delta++) {
-            if ((int)payload_offset + delta < 0) continue;
-            uint8_t *cand = base + payload_offset + delta;
-            if ((cand[0] >> 4) == 4 && (cand[0] & 0x0F) >= 5) {
-                UTLT_Info("Adjusted payload_offset from %u to %u",
-                             payload_offset, payload_offset + delta);
-                payload_offset += delta;
-                inner_ptr = cand;
-                found = 1;
-                break;
-            }
-        }
-        if (!found) {
-            UTLT_Error("Failed to locate a valid IPv4 header near offset %u", payload_offset);
-            return NULL;
-        }
-    }
-
-    // Inner IPv4
-    if (data_len < (inner_ptr - rte_pktmbuf_mtod(pkt, uint8_t *)) + sizeof(struct rte_ipv4_hdr))
-        return NULL;
-    struct rte_ipv4_hdr *inner4 = (struct rte_ipv4_hdr *)inner_ptr;
     uint8_t inner_ihl = (inner4->version_ihl & 0x0F) * 4;
+    struct rte_udp_hdr *innerU = rte_pktmbuf_mtod_offset(pkt, struct rte_udp_hdr *,
+        inner_offset + inner_ihl);
 
-    // Inner UDP
-    if (data_len < (inner_ptr - rte_pktmbuf_mtod(pkt, uint8_t *)) + inner_ihl + sizeof(struct rte_udp_hdr))
-        return NULL;
-    struct rte_udp_hdr *innerU = (struct rte_udp_hdr *)(inner_ptr + inner_ihl);
-
-    UTLT_Debug("Inner IPv4 src=%s dst=%s proto=%u QFI=%u",
-               ip4_to_buf(inner4->src_addr, i_src),
-               ip4_to_buf(inner4->dst_addr, i_dst),
-               inner4->next_proto_id, qfi);
-
-    // Build classifier key
+    // Build classifier key using pre-parsed values
     ps_packet_t key = {0};
-    key.teid      = teid;
+    key.teid      = gtp_info->teid;
+    key.qfi       = gtp_info->qfi;
     key.ue_ip     = rte_be_to_cpu_32(inner4->src_addr);
     key.src_ip    = key.ue_ip;
     key.dst_ip    = rte_be_to_cpu_32(inner4->dst_addr);
@@ -846,7 +787,6 @@ UPDK_PDR *GetPdrByTeid(struct rte_mbuf *pkt, uint32_t td) {
     key.dst_port  = rte_be_to_cpu_16(innerU->dst_port);
     key.proto     = inner4->next_proto_id;
     key.tos_tc    = inner4->type_of_service;
-    key.qfi       = qfi;
     key.source_if = SRC_IF_ACCESS;
     key.is_uplink = true;
 
@@ -896,7 +836,7 @@ UPDK_PDR *GetPdrByTeid(struct rte_mbuf *pkt, uint32_t td) {
         return NULL;
     }
 
-    UpfSession *session = UpfSessionFindByTeid(td);
+    UpfSession *session = UpfSessionFindByTeid(gtp_info->teid);
     if (session) {
         ConfigureQerFlows(session, pdr, pkt->port, true);
     }
@@ -946,6 +886,51 @@ GetQerByUEIpAddress(uint32_t ue_ip, char *IP) {
         return NULL;
     }
 }
+
+/* Populate UE table using the already-classified UPDK_PDR (no session/pdr_list scan).
+ * DL-only: uses qer->*.dl fields.
+ * Returns NULL to match the old function style. */
+static inline void *
+GetQerByUEIpAddressFromPdr(uint32_t ue_ip, const UPDK_PDR *pdr, const char *ip_str)
+{
+    if ((int)findIndexByUeIpAddress(ue_ip) != -1) {
+        UTLT_Trace("The UE IP already exists in the table");
+        return NULL;
+    }
+
+    if (!pdr || !pdr->qer) {
+        UTLT_Warning("UE %s: no PDR/QER, cannot populate UE table",
+                     ip_str ? ip_str : "<unknown>");
+        return NULL;
+    }
+
+    const UPDK_QER *qer = pdr->qer;
+
+    /* Respect presence; avoid using uninitialized values */
+    if (!qer->flags.maximumBitrate || qer->maximumBitrate.dl == 0) {
+        UTLT_Trace("UE %s: no DL MBR, skip UE table entry",
+                   ip_str ? ip_str : "<unknown>");
+        return NULL;
+    }
+
+    /* Clamp 64-bit PFCP rates into 32-bit UE table fields */
+    uint64_t mbr64  = qer->maximumBitrate.dl;
+    uint64_t gbr64  = qer->flags.guaranteedBitrate ? qer->guaranteedBitrate.dl : 0;
+
+    uint32_t mbr  = (mbr64 > UINT32_MAX) ? UINT32_MAX : (uint32_t)mbr64;
+    uint32_t ambr = mbr;  /* with only one PDR/QER, AMBR ~= MBR */
+    uint32_t gbr  = (gbr64 > UINT32_MAX) ? UINT32_MAX : (uint32_t)gbr64;
+
+    /* Prevent unsigned underflow in addEntrybyUeIp() math if CP gives weird values */
+    if (gbr > mbr) gbr = mbr;
+
+    UTLT_Warning("Add UE IP: %s, AMBR: %u GBR: %u, MBR: %u",
+                 ip_str ? ip_str : "<unknown>", ambr, gbr, mbr);
+
+    addEntrybyUeIp(ue_ip, ambr, gbr, mbr);
+    return NULL;
+}
+
 
 void
 Encap(struct rte_mbuf *pkt, UPDK_FAR *far, UPDK_QER *qer) {
@@ -1105,11 +1090,12 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
     UpfClsMaybeFlipAndAck();
 
     UPDK_PDR *pdr = NULL;
+    gtp_parse_result_t gtp_info = {0};
 
-    char *src_address = convertToIpAddress(iph->src_addr);
+    /* char *src_address = convertToIpAddress(iph->src_addr);
     UTLT_Info("Src IP is %s\n", src_address);
     char *dst_address = convertToIpAddress(iph->dst_addr);
-    UTLT_Info("Dst IP is %s\n", dst_address);
+    UTLT_Info("Dst IP is %s\n", dst_address); */
 
     if (iph->dst_addr == SELF_IP) {  //
         UTLT_Info("It is uplink\n");
@@ -1118,16 +1104,15 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
         if (udp_header == NULL) {
             return 0;
         }
-        // invariant(dst_port == GTPV1_PORT);
-        // extract TEID from
-        // Step 2: Get PDR rule
-        uint32_t teid = get_teid_gtp_packet(pkt, udp_header);
-        pdr = GetPdrByTeid(pkt, teid);
+
+        if (parse_gtpu_once(pkt, &gtp_info) < 0 || !gtp_info.valid) {
+            return 0;
+        }
+        pdr = GetPdrByTeid(pkt, &gtp_info);
 
     } else {
         UTLT_Info("It is downlink, dst is %s\n", convertToIpAddress(iph->dst_addr));
         pdr = GetPdrByUeIpAddress(pkt, rte_cpu_to_be_32(iph->dst_addr));
-        GetQerByUEIpAddress(rte_cpu_to_be_32(iph->dst_addr), convertToIpAddress(iph->dst_addr));
         is_dl = true;
     }
 
@@ -1137,6 +1122,11 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
         return 0;
     }
     UTLT_Info("Got PDR ID is %u\n", pdr->pdrId);
+
+    if (is_dl) {
+        GetQerByUEIpAddressFromPdr(rte_cpu_to_be_32(iph->dst_addr), pdr, convertToIpAddress(iph->dst_addr));
+    }
+
     rte_pktmbuf_adj(pkt, sizeof(struct rte_ether_hdr));
 
     UPDK_FAR *far;
@@ -1148,16 +1138,9 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
     }
 
     if (pdr->flags.outerHeaderRemoval) {
-        uint16_t outerHeaderLen = 0;
         switch (pdr->outerHeaderRemoval) {
             case OUTER_HEADER_REMOVAL_GTP_IP4: {
-                outerHeaderLen = sizeof(struct rte_ipv4_hdr) + sizeof(struct rte_udp_hdr);
-
-                // get gtp_header length
-                uint16_t gtp_length = get_gtpu_header_len(pkt);
-                outerHeaderLen += gtp_length;
-
-                rte_pktmbuf_adj(pkt, outerHeaderLen);
+                rte_pktmbuf_adj(pkt, gtp_info.outer_hdr_len);
             } break;
             case OUTER_HEADER_REMOVAL_GTP_IP6:
             case OUTER_HEADER_REMOVAL_UDP_IP4:

--- a/onvm/updk/updk/rule_pdr.h
+++ b/onvm/updk/updk/rule_pdr.h
@@ -259,6 +259,9 @@ typedef struct {
     uint32_t farId;
     UPDK_FAR *far;
     UPDK_QER *qer;
+
+    UPDK_QER *qers[2];
+    uint8_t   qer_count;
     
     // handle multiple URR
     uint32_t urrId[4];

--- a/onvm/upf/gtp.h
+++ b/onvm/upf/gtp.h
@@ -163,6 +163,21 @@ struct gtp_hdr_v2_without_teid {
   uint32_t sequence_number_and_spare;
 };
 
+
+/**
+ * Unified GTP-U header parsing - call ONCE, use everywhere.
+ * Assumes Ethernet header is PRESENT (call before any rte_pktmbuf_adj).
+ */
+
+typedef struct {
+    uint32_t teid;           // Extracted TEID (host byte order)
+    uint8_t  qfi;            // QFI from PDU Session Container (0 if absent)
+    uint16_t gtp_hdr_len;    // Total GTP-U header length (for decap)
+    uint16_t outer_hdr_len;  // IP + UDP + GTP total (for decap)
+    bool     valid;          // true if parsing succeeded
+} gtp_parse_result_t;
+
+
 /*
         Enum for dereferencing void *.
 */
@@ -423,3 +438,87 @@ static inline uint16_t get_gtpu_header_len_with_qfi(struct rte_mbuf *pkt, uint8_
     return gtp_len;
 }
 
+
+static inline int parse_gtpu_once(struct rte_mbuf *pkt, gtp_parse_result_t *result) {
+    memset(result, 0, sizeof(*result));
+
+    // Check packet length
+    uint16_t data_len = rte_pktmbuf_data_len(pkt);
+    size_t min_len = sizeof(struct rte_ether_hdr) + sizeof(struct rte_ipv4_hdr) +
+                     sizeof(struct rte_udp_hdr) + sizeof(gtpv1_t);
+    if (data_len < min_len) return -1;
+
+    // Get outer IPv4 header
+    struct rte_ipv4_hdr *outer_ip = rte_pktmbuf_mtod_offset(pkt, struct rte_ipv4_hdr *,
+        sizeof(struct rte_ether_hdr));
+    uint8_t ip_hdr_len = (outer_ip->version_ihl & 0x0F) * 4;
+
+    // Get outer UDP header
+    struct rte_udp_hdr *outer_udp = rte_pktmbuf_mtod_offset(pkt, struct rte_udp_hdr *,
+        sizeof(struct rte_ether_hdr) + ip_hdr_len);
+
+    // Verify GTP-U port
+    if (outer_udp->dst_port != rte_cpu_to_be_16(UDP_PORT_FOR_GTP)) return -1;
+
+    // Get GTP header
+    gtpv1_t *gtp = rte_pktmbuf_mtod_offset(pkt, gtpv1_t *,
+        sizeof(struct rte_ether_hdr) + ip_hdr_len + sizeof(struct rte_udp_hdr));
+
+    // Extract TEID
+    result->teid = rte_be_to_cpu_32(gtp->teid);
+    result->gtp_hdr_len = sizeof(gtpv1_t);
+    result->qfi = 0;
+
+    // Check for optional fields (seq, npdu, ext)
+    if (gtp->flags & GTP1_F_MASK) {
+        result->gtp_hdr_len += 4;  // seq(2) + npdu(1) + next_ext(1)
+
+        // Check for extension headers
+        if (gtp->flags & GTP1_F_EXTHDR) {
+            gtpv1_hdr_opt_t *opt = rte_pktmbuf_mtod_offset(pkt, gtpv1_hdr_opt_t *,
+                sizeof(struct rte_ether_hdr) + ip_hdr_len +
+                sizeof(struct rte_udp_hdr) + sizeof(gtpv1_t));
+
+            uint8_t next_type = opt->next_ehdr_type;
+            size_t ext_offset = sizeof(struct rte_ether_hdr) + ip_hdr_len +
+                                sizeof(struct rte_udp_hdr) + sizeof(gtpv1_t) +
+                                sizeof(gtpv1_hdr_opt_t);
+
+            while (next_type) {
+                if (next_type == GTPV1_NEXT_EXT_HDR_TYPE_85) {
+                    // PDU Session Container - extract QFI
+                    if (ext_offset + sizeof(pdu_sess_container_hdr_t) > data_len) return -1;
+                    pdu_sess_container_hdr_t *psc = rte_pktmbuf_mtod_offset(pkt,
+                        pdu_sess_container_hdr_t *, ext_offset);
+
+                    size_t ext_len = (size_t)psc->length * 4;
+                    if (ext_len == 0 || ext_offset + ext_len > data_len) return -1;
+
+                    uint8_t *raw = (uint8_t *)psc;
+                    result->qfi = raw[2] & 0x3F;
+
+                    result->gtp_hdr_len += ext_len;
+                    next_type = psc->next_hdr;
+                    ext_offset += ext_len;
+                } else {
+                    // Unknown extension - skip by length
+                    if (ext_offset + 1 > data_len) return -1;
+                    uint8_t *ext = rte_pktmbuf_mtod_offset(pkt, uint8_t *, ext_offset);
+                    uint8_t len_units = ext[0];
+                    size_t ext_len = (size_t)len_units * 4;
+                    if (ext_len == 0 || ext_offset + ext_len > data_len) return -1;
+
+                    result->gtp_hdr_len += ext_len;
+                    next_type = ext[ext_len - 1];
+                    ext_offset += ext_len;
+                }
+          }
+        }
+    }
+
+    // Calculate total outer header length (for decap)
+    result->outer_hdr_len = ip_hdr_len + sizeof(struct rte_udp_hdr) + result->gtp_hdr_len;
+    result->valid = true;
+
+    return 0;
+}


### PR DESCRIPTION
This PR optimizes the UPF-U fastpath by:

1. parsing the outer GTP-U header once per packet and reusing the parsed TEID/QFI + header lengths throughout the uplink path, and 
2. eliminating the downlink “scan `session->pdr_list` to find QERs” slow path by using QER pointers already attached to the classified PDR.

It also fixes a correctness issue where the dataplane could pick the wrong QER (e.g., `qerId[0]` with no `maximumBitrate`) even though the “real” MBR lived in another associated QER.

---

### Key changes

#### `gtp.h`

- Add gtp_parse_result_t and parse_gtpu_once() to extract (once): teid, qfi, gtp_hdr_len, and outer_hdr_len (IP+UDP+GTP).

- Extension header parsing now supports PDU Session Container (type 0x85) and skips unknown extensions using their length field (prevents premature stop on unknown ext headers).

#### `upf_u.c`

- Uplink: call `parse_gtpu_once()` once and pass the result into `GetPdrByTeid()` (signature updated) to avoid repeated TEID/QFI/header-length parsing.
- Uplink decap: use `gtp_info.outer_hdr_len` for `OUTER_HEADER_REMOVAL_GTP_IP4` instead of recomputing `sizeof(ip)+sizeof(udp)+get_gtpu_header_len(...)`.
- Downlink UE QoS table: add `GetQerByUEIpAddressFromPdr()` which derives AMBR/GBR/MBR from `pdr->qers[]` , and inserts into ue_table **without scanning `session->pdr_list`**.
- Make addEntrybyUeIp() return the allocated UE index; cache that ue_idx in packet_handler() to avoid redundant table lookups.


#### `rule_pdr.h`

- Extend UPDK_PDR with `UPDK_QER *qers[2];` and `uint8_t qer_count;` to carry all associated QER pointers into dataplane, while keeping `pdr->qer` for legacy call sites.


#### `n4_onvm_pfcp_handler.c`

- CreatePDR: populate `pdr->qers[]` + `qer_count` by resolving all `qerId[]` entries; set `pdr->qer = qers[0]` for backward compatibility.
- UpdatePDR: when `qERID` is present, add the new QER ID into the first free slot (or no-op if already present; warn+ignore if both slots are occupied).
- UpdatePDR handler refreshes `pdr->qers[]/qer_count/pdr->qer` after updates so dataplane pointers don’t go stale.


---

_**[Tested on Ubuntu 22.04]**_



