### PR TITLE
Refactor UPF-U ARP integration and switch UL/DL forwarding to ARP-based next-hop resolution

### DIFF
--- a/5gc/upf_u/config/upf_u.yaml
+++ b/5gc/upf_u/config/upf_u.yaml
@@ -3,14 +3,13 @@ info:
   description: L25GC+ UPF-U Configuration
 
 configuration:
+  log_level: "warning" # trace, debug, info, warning, error, fatal, panic
   dataplane:
-    dn_mac: "3c:fd:fe:b4:fe:21"
-    an_mac: "3c:fd:fe:b5:00:14"
     upf_access_ip: "192.168.1.2"    # UPF local IP on the access-facing port
     upf_core_ip: "192.168.1.2"      # UPF local IP on the core/SGi-facing port
-    an_peer_ip: "192.168.1.2"  # Next-hop IP of the AN/gNB peer
-    dn_peer_ip: "192.168.1.2"  # Next-hop IP of the DN/upstream router peer
+    an_peer_ip: "192.168.1.1"  # Next-hop IP of the AN/gNB peer
+    dn_peer_ip: "192.168.1.4"  # Next-hop IP of the DN/upstream router peer
 
     ports:
-      access: 0                     # ACCESS_PORT
-      core: 1                       # CORE_PORT (SGi follows CORE)
+      access: 1                     # ACCESS_PORT
+      core: 0                       # CORE_PORT (SGi follows CORE)

--- a/5gc/upf_u/config/upf_u.yaml
+++ b/5gc/upf_u/config/upf_u.yaml
@@ -1,12 +1,15 @@
 info:
   version: 1.0.0
-  description: L25GC-plus UPF-U dataplane configuration
+  description: L25GC+ UPF-U Configuration
 
 configuration:
   dataplane:
     dn_mac: "3c:fd:fe:b4:fe:21"
     an_mac: "3c:fd:fe:b5:00:14"
-    upf_ip: "192.168.1.2"
+    upf_access_ip: "192.168.1.2"    # UPF local IP on the access-facing port
+    upf_core_ip: "192.168.1.2"      # UPF local IP on the core/SGi-facing port
+    an_peer_ip: "192.168.1.2"  # Next-hop IP of the AN/gNB peer
+    dn_peer_ip: "192.168.1.2"  # Next-hop IP of the DN/upstream router peer
 
     ports:
       access: 0                     # ACCESS_PORT

--- a/5gc/upf_u/meson.build
+++ b/5gc/upf_u/meson.build
@@ -1,6 +1,8 @@
 sources = files(
     'upf_u.c',
-    'upf_u_config.c'
+    'upf_u_config.c',
+    'upf_u_arp.c',
+    'upf_u_helper.c'
 )
 
 upf_u_link_deps = [

--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -639,7 +639,7 @@ GetPdrByUeIpAddress(struct rte_mbuf *pkt, uint32_t ue_ip)
 
 UPDK_PDR *
 GetPdrByTeid(struct rte_mbuf *pkt, const gtp_parse_result_t *gtp_info) {
-        // Locate inner IP header using pre-computed offset
+    // Locate inner IP header using pre-computed offset
     size_t inner_offset = sizeof(struct rte_ether_hdr) + gtp_info->outer_hdr_len;
 
     uint16_t data_len = rte_pktmbuf_data_len(pkt);
@@ -815,7 +815,7 @@ Encap(struct rte_mbuf *pkt, UPDK_FAR *far, UPDK_QER *qer) {
                               // udppayloadlen should be raw + gtp header
 
     struct rte_ipv4_hdr *ipv4_hdr = rte_pktmbuf_mtod_offset(pkt, struct rte_ipv4_hdr *, 0);
-    onvm_pkt_fill_ipv4(ipv4_hdr, rte_cpu_to_be_32(UPF_U_IP), rte_cpu_to_be_32(outerHeaderCreation->ipv4.s_addr),
+    onvm_pkt_fill_ipv4(ipv4_hdr, rte_cpu_to_be_32(g_access_ip_be), rte_cpu_to_be_32(outerHeaderCreation->ipv4.s_addr),
                IPPROTO_UDP);
     ipv4_hdr->total_length = rte_cpu_to_be_16(payloadLen + sizeof(gtpv1_t) + sizeof(struct rte_udp_hdr) +
                           sizeof(struct rte_ipv4_hdr));  // raw+gtp8+udp8+ip20
@@ -881,25 +881,6 @@ HandlePacketWithFar(struct rte_mbuf *pkt, UPDK_FAR *far, UPDK_QER *qer,
         }
     }
     return buff;
-}
-
-static inline void
-AttachL2Header(struct rte_mbuf *pkt, bool is_dl) {
-    // Prepend ethernet header
-    struct rte_ether_hdr *eth_hdr =
-        (struct rte_ether_hdr *)rte_pktmbuf_prepend(pkt, (uint16_t)sizeof(struct rte_ether_hdr));
-
-    // next hop's mac address
-    if (is_dl == true) {
-        rte_ether_addr_copy(&g_cn_ue_eth, &eth_hdr->src_addr);
-        rte_ether_addr_copy(&g_an_eth, &eth_hdr->dst_addr);
-
-    } else {
-        rte_ether_addr_copy(&g_cn_dn_eth, &eth_hdr->src_addr);
-        rte_ether_addr_copy(&g_dn_eth, &eth_hdr->dst_addr);
-    }
-
-    eth_hdr->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4);
 }
 
 /* Per-session drain helper
@@ -986,7 +967,7 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
     char *dst_address = convertToIpAddressString(iph->dst_addr);
     UTLT_Info("Dst IP is %s\n", dst_address); */
 
-    if (iph->dst_addr == UPF_U_IP) {  //
+    if (iph->dst_addr == g_access_ip_be) {  //
         UTLT_Info("It is uplink\n");
 
         struct rte_udp_hdr *udp_header = onvm_pkt_udp_hdr(pkt);
@@ -1267,8 +1248,7 @@ main(int argc, char *argv[]) {
     int arg_offset;
     struct onvm_nf_local_ctx *nf_local_ctx;
     struct onvm_nf_function_table *nf_function_table;
-    // UTLT_SetLogLevel("Panic"); // to eliminate log print influenced jitter
-    UTLT_SetLogLevel("warning"); // to eliminate log print influenced jitter
+    UTLT_SetLogLevel("warning"); // temporary default before config is loaded
 
     nf_local_ctx = onvm_nflib_init_nf_local_ctx();
     onvm_nflib_start_signal_handler(nf_local_ctx, NULL);
@@ -1287,6 +1267,10 @@ main(int argc, char *argv[]) {
         }
     }
 
+    /* Initialize dynamic field offset */
+    struct onvm_configuration *onvm_config = onvm_nflib_get_onvm_config();
+    nf_local_ctx->nf->dynfield_offset = onvm_config->dynfield_offset;
+
     const char *config_path = "config/upf_u.yaml";
 
     if (argc > arg_offset + 1) {
@@ -1297,6 +1281,9 @@ main(int argc, char *argv[]) {
     if (UpfU_LoadAndParseConfig(config_path) != 0) {
         rte_exit(EXIT_FAILURE, "Failed to load/parse UPF-U YAML config.\n");
     }
+
+    UTLT_SetLogLevel(g_log_level);
+    printf("[UPF-U] Log level: %s\n", g_log_level);
 
     if (UpfClsCtrlInit() < 0) {
         rte_exit(EXIT_FAILURE, "CLS_CTRL memzone init failed\n");

--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -1,5 +1,5 @@
 /*
-# Copyright 2025 University of California, Riverside and National Yang Ming Chiao Tung University
+# Copyright 2026 University of California, Riverside and National Yang Ming Chiao Tung University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,37 +51,19 @@
 #include "../classifiers/upf_cls_adapter.h"
 #include "../classifiers/classifier_wrapper.h"
 
+#include "upf_u_helper.h"
 #include "upf_u_config.h"
+#include "upf_u_arp.h"
 
 #define NF_TAG "upf_u"
 
-// #if 0
-// #define SELF_IP RTE_IPV4(10, 100, 200, 3)
-// #else
-// #define SELF_IP 33622538  // 10.10.1.2
-
-// #endif
-
-// #define SRC_INTF_ACCESS 0
-// #define SRC_INTF_CORE 1
-// #define SRC_INTF_SGI_LAN 2
-// #define SRC_INTF_CP 3
-// #define SRC_INTF_NUM (SRC_INTF_CP + 1)
-#define FIX_BUFFER
-#define DEFAULT_TB_RATE 10         // (Mbps)
-#define DEFAULT_TB_DEPTH 10000  // Max proceed length
-#define DEFAULT_TB_TOKENS 10000
 #define APP_FLOWS_MAX 256
-#define IP_MASKED(BIGENDIINT, LEN) (BIGENDIINT & (0xFFFFFFFF << (32-LEN)))
 #define MAX_UE 256 // Max number of UEs
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
+
+/* Used for buffering */
 #define INLINE_DRAIN_BATCH       8    /* pkts drained per INLINE (FORW)  */
 #define DRAIN_CHUNK             64    /* max pkts dequeued per drain call */
-
-/* mask for 20-bit IPv6 flow label */
-#ifndef IPV6_FLOWLABEL_MASK
-#define IPV6_FLOWLABEL_MASK 0x000FFFFFu
-#endif
 
 
 static inline int UpfSendEvt1(uint16_t dest_sid, uint32_t type, uintptr_t a0) {
@@ -95,21 +77,7 @@ static inline int UpfSendEvt1(uint16_t dest_sid, uint32_t type, uintptr_t a0) {
     return rc;
 }
 
-static struct rte_ether_addr dn_eth;
-static struct rte_ether_addr an_eth;
-static struct rte_ether_addr cn_dn_eth;
-static struct rte_ether_addr cn_ue_eth;
-
-uint8_t DnMac[RTE_ETHER_ADDR_LEN];
-uint8_t AnMac[RTE_ETHER_ADDR_LEN];
-int SELF_IP;
-
 enum { IF_UNKNOWN = -1 };
-
-int16_t g_access_port = 0;
-int16_t g_core_port   = 0;
-int16_t g_sgi_port    = 0;
-
 
 struct rte_meter_trtcm_profile app_trtcm_profile;
 struct rte_meter_trtcm_profile app_flow_trtcm_profile;
@@ -146,7 +114,8 @@ typedef struct {
 static upf_cls_local_t g_cls_local = {0};
 
 // Flip to the latest published snapshot (called at burst boundary)
-static inline void UpfClsMaybeFlipAndAck(void) {
+static inline void
+UpfClsMaybeFlipAndAck(void) {
     if (likely(!g_cls_local.flip_pending))
         return;
 
@@ -187,7 +156,8 @@ static inline void UpfClsMaybeFlipAndAck(void) {
 }
 
 
-/* static inline const UPDK_PDR *UpfLookupPdr(const ps_packet_t *key) {
+/* static inline const UPDK_PDR *
+UpfLookupPdr(const ps_packet_t *key) {
     const cls_handle_t *snap = (const cls_handle_t *)g_cls_local.ptr;
     if (unlikely(!snap)) return NULL;
 
@@ -199,7 +169,8 @@ static inline void UpfClsMaybeFlipAndAck(void) {
     return (const UPDK_PDR *)cookie;
 } */
 
-static inline uint16_t UpfClassifyGetPdrId(const ps_packet_t *key) {
+static inline uint16_t
+UpfClassifyGetPdrId(const ps_packet_t *key) {
     const cls_handle_t *snap = (const cls_handle_t *)g_cls_local.ptr;
     if (unlikely(!snap)) {
         UTLT_Warning("CLS classify: no snapshot yet (ver=%u) — dropping", g_cls_local.ver);
@@ -220,7 +191,8 @@ static inline uint16_t UpfClassifyGetPdrId(const ps_packet_t *key) {
     return (uint16_t)pdrId;
 }
 
-static inline const UPDK_PDR *UpfClassifyGetPdrPtr(const ps_packet_t *key) {
+static inline const UPDK_PDR *
+UpfClassifyGetPdrPtr(const ps_packet_t *key) {
     const cls_handle_t *snap = (const cls_handle_t *)g_cls_local.ptr;
     if (unlikely(!snap)) {
         UTLT_Warning("CLS classify: no snapshot yet (ver=%u) — dropping", g_cls_local.ver);
@@ -233,9 +205,8 @@ static inline const UPDK_PDR *UpfClassifyGetPdrPtr(const ps_packet_t *key) {
     return (const UPDK_PDR *)descriptor;
 }
 
-
-
-bool ftAddEntry(uint32_t subnet, int flow_idx) {
+bool
+ftAddEntry(uint32_t subnet, int flow_idx) {
     if (iPFlowsLen >= APP_FLOWS_MAX) {
         printf("Error: Maximum flow entries reached.\n");
         return false;
@@ -260,25 +231,8 @@ bool ftAddEntry(uint32_t subnet, int flow_idx) {
     return true;
 }
 
-const char *ip4(uint32_t host_ip) {
-    static char buf[16];
-    struct in_addr a = { .s_addr = htonl(host_ip) };
-    return inet_ntop(AF_INET, &a, buf, sizeof(buf)) ? buf : "<err>";
-}
-
-uint32_t charStr2MaskedIP(char *str, uint32_t *prefix_val){
-    char ip_str[INET_ADDRSTRLEN];
-    uint32_t prefix_len, subnet;
-
-    sscanf(str, "%[^/]/%d", ip_str, &prefix_len);
-    struct in_addr ip_addr;
-    inet_pton(AF_INET, ip_str, &ip_addr);
-
-    if (prefix_val) *prefix_val = prefix_len;
-    return IP_MASKED(ip_addr.s_addr, prefix_len);
-}
-
-static inline int SourceInterfaceToPort(source_interface_t srcIf) {
+static inline uint16_t
+SourceInterfaceToPort(source_interface_t srcIf) {
     switch (srcIf) {
       case SRC_IF_ACCESS:   return g_access_port;
       case SRC_IF_CORE:     return g_core_port;
@@ -355,50 +309,18 @@ ConfigureQerFlows(const UPDK_PDR *pdr, bool is_uplink)
     trTCMidx++;
 }
 
-char *
-convertToIpAddress(uint32_t big_endian_value) {
-    static char ip_string[16];
+// static inline source_interface_t
+// PortToSourceInterface(uint16_t port) {
+//     if (port == g_access_port)  return SRC_IF_ACCESS;
+//     if (port == g_core_port)    return SRC_IF_CORE;
+//     if (port == g_sgi_port)     return SRC_IF_SGI_LAN;
+//     UTLT_Warning("PortToSourceInterface: unknown port %" PRIu16
+//              " (ACCESS=%" PRIu16 " CORE=%" PRIu16 " SGI=%" PRIu16
+//              ") — defaulting to ACCESS",
+//              port, g_access_port, g_core_port, g_sgi_port);
 
-    uint8_t ip_address[4];
-    ip_address[0] = (big_endian_value >> 24) & 0xFF;
-    ip_address[1] = (big_endian_value >> 16) & 0xFF;
-    ip_address[2] = (big_endian_value >> 8) & 0xFF;
-    ip_address[3] = big_endian_value & 0xFF;
-
-    sprintf(ip_string, "%d.%d.%d.%d", ip_address[3], ip_address[2], ip_address[1], ip_address[0]);
-
-    return ip_string;
-}
-
-int
-parseIpv4Address(const char *addrStr) {
-    const char *p = addrStr;
-    char *endp;
-
-    unsigned long a = strtoul(p, &endp, 10);
-    if (*endp != '.')
-        return -1;
-    unsigned long b = strtoul(p = endp + 1, &endp, 10);
-    if (*endp != '.')
-        return -1;
-    unsigned long c = strtoul(p = endp + 1, &endp, 10);
-    if (*endp != '.')
-        return -1;
-    unsigned long d = strtoul(p = endp + 1, &endp, 10);
-
-    SELF_IP = (uint32_t)((d << 24) | (c << 16) | (b << 8) | a);
-    UTLT_Info("IP Address: %s -> %d\n", addrStr, SELF_IP);
-    return 0;
-}
-
-static inline source_interface_t PortToSourceInterface(uint8_t port) {
-    if ((int)port == g_access_port)  return SRC_IF_ACCESS;
-    if ((int)port == g_core_port)    return SRC_IF_CORE;
-    if ((int)port == g_sgi_port)     return SRC_IF_SGI_LAN;
-    UTLT_Warning("PortToSourceInterface: unknown port %u (ACCESS=%d CORE=%d SGI=%d) — defaulting to ACCESS",
-                 port, g_access_port, g_core_port, g_sgi_port);
-    return SRC_IF_ACCESS;
-}
+//     return SRC_IF_ACCESS;
+// }
 
 static int
 trtcmConfigFlowTables(void){
@@ -496,13 +418,11 @@ int ftSearch(uint32_t subnet) {
     return -1;  // Not found
 }
 
-
-
-void ftInit() {
-    for (int i = 0; i < APP_FLOWS_MAX; i++) {
-        iPFlows[i].in_use = false;
-    }
-}
+// void ftInit() {
+//     for (int i = 0; i < APP_FLOWS_MAX; i++) {
+//         iPFlows[i].in_use = false;
+//     }
+// }
 
 /* Token Bucket */
 struct tb_config {
@@ -717,22 +637,8 @@ GetPdrByUeIpAddress(struct rte_mbuf *pkt, uint32_t ue_ip)
     return pdr;
 }
 
-static inline const char *
-ip4_to_buf(uint32_t be_addr, char buf[16]) {
-  inet_ntop(AF_INET, &be_addr, buf, 16);
-  return buf;
-}
-
-static void dump_gtpu(const uint8_t *start, size_t len, size_t gtp_off) {
-    printf("---- GTPU Dump (offset %zu, %zu bytes) ----\n", gtp_off, len);
-    for (size_t i = 0; i < len; i++) {
-        if (i % 16 == 0) printf("\n%04zu : ", i);
-        printf("%02x ", start[i]);
-    }
-    printf("\n------------------------------------------\n");
-}
-
-UPDK_PDR *GetPdrByTeid(struct rte_mbuf *pkt, const gtp_parse_result_t *gtp_info) {
+UPDK_PDR *
+GetPdrByTeid(struct rte_mbuf *pkt, const gtp_parse_result_t *gtp_info) {
         // Locate inner IP header using pre-computed offset
     size_t inner_offset = sizeof(struct rte_ether_hdr) + gtp_info->outer_hdr_len;
 
@@ -909,7 +815,7 @@ Encap(struct rte_mbuf *pkt, UPDK_FAR *far, UPDK_QER *qer) {
                               // udppayloadlen should be raw + gtp header
 
     struct rte_ipv4_hdr *ipv4_hdr = rte_pktmbuf_mtod_offset(pkt, struct rte_ipv4_hdr *, 0);
-    onvm_pkt_fill_ipv4(ipv4_hdr, rte_cpu_to_be_32(SELF_IP), rte_cpu_to_be_32(outerHeaderCreation->ipv4.s_addr),
+    onvm_pkt_fill_ipv4(ipv4_hdr, rte_cpu_to_be_32(UPF_U_IP), rte_cpu_to_be_32(outerHeaderCreation->ipv4.s_addr),
                IPPROTO_UDP);
     ipv4_hdr->total_length = rte_cpu_to_be_16(payloadLen + sizeof(gtpv1_t) + sizeof(struct rte_udp_hdr) +
                           sizeof(struct rte_ipv4_hdr));  // raw+gtp8+udp8+ip20
@@ -917,7 +823,8 @@ Encap(struct rte_mbuf *pkt, UPDK_FAR *far, UPDK_QER *qer) {
 }
 
 static int
-HandlePacketWithFar(struct rte_mbuf *pkt, UPDK_FAR *far, UPDK_QER *qer, struct onvm_pkt_meta *meta) {
+HandlePacketWithFar(struct rte_mbuf *pkt, UPDK_FAR *far, UPDK_QER *qer, 
+                    uint16_t out_port, struct onvm_pkt_meta *meta) {
     int buff = 0;
 #define FAR_ACTION_MASK 0x07
     if (far->flags.applyAction) {
@@ -942,7 +849,8 @@ HandlePacketWithFar(struct rte_mbuf *pkt, UPDK_FAR *far, UPDK_QER *qer, struct o
                         }
                     }
                 }
-                meta->destination = pkt->port ^ 1;
+                // meta->destination = pkt->port ^ 1;
+                meta->destination = out_port;
                 meta->action = ONVM_NF_ACTION_OUT;
                 break;
             case UPDK_FAR_APPLY_ACTION_BUFF:
@@ -983,12 +891,12 @@ AttachL2Header(struct rte_mbuf *pkt, bool is_dl) {
 
     // next hop's mac address
     if (is_dl == true) {
-        rte_ether_addr_copy(&cn_ue_eth, &eth_hdr->src_addr);
-        rte_ether_addr_copy(&an_eth, &eth_hdr->dst_addr);
+        rte_ether_addr_copy(&g_cn_ue_eth, &eth_hdr->src_addr);
+        rte_ether_addr_copy(&g_an_eth, &eth_hdr->dst_addr);
 
     } else {
-        rte_ether_addr_copy(&cn_dn_eth, &eth_hdr->src_addr);
-        rte_ether_addr_copy(&dn_eth, &eth_hdr->dst_addr);
+        rte_ether_addr_copy(&g_cn_dn_eth, &eth_hdr->src_addr);
+        rte_ether_addr_copy(&g_dn_eth, &eth_hdr->dst_addr);
     }
 
     eth_hdr->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4);
@@ -1037,6 +945,20 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
     if (pkt == NULL || meta == NULL) {
         return 0;
     }
+
+    /* Get Ethernet header */
+    struct rte_ether_hdr *eth = onvm_pkt_ether_hdr(pkt);
+    if (!eth) {
+        meta->action = ONVM_NF_ACTION_DROP;
+        return 0;
+    }
+
+    /* Handle ARP packets */
+    if (rte_be_to_cpu_16(eth->ether_type) == RTE_ETHER_TYPE_ARP) {
+        handle_arp_packet(pkt, meta, nf_local_ctx);
+        return 0;
+    }
+
     uint32_t cal_pktlen = 0;
     UTLT_Trace("Get packet\n");
     UTLT_Info("Handle PKT from port: %d [len: %d]", pkt->port, pkt->pkt_len);
@@ -1044,8 +966,9 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
 
     bool is_dl = false;
     meta->action = ONVM_NF_ACTION_DROP;
-    struct rte_ipv4_hdr *iph = onvm_pkt_ipv4_hdr(pkt);
 
+    /* Get IPv4 header */
+    struct rte_ipv4_hdr *iph = onvm_pkt_ipv4_hdr(pkt);
     if (iph == NULL) {
         UTLT_Info("Not IP packet, ignore it\n");
         return 0;
@@ -1058,12 +981,12 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
     gtp_parse_result_t gtp_info = {0};
     int ue_idx = -1;
 
-    /* char *src_address = convertToIpAddress(iph->src_addr);
+    /* char *src_address = convertToIpAddressString(iph->src_addr);
     UTLT_Info("Src IP is %s\n", src_address);
-    char *dst_address = convertToIpAddress(iph->dst_addr);
+    char *dst_address = convertToIpAddressString(iph->dst_addr);
     UTLT_Info("Dst IP is %s\n", dst_address); */
 
-    if (iph->dst_addr == SELF_IP) {  //
+    if (iph->dst_addr == UPF_U_IP) {  //
         UTLT_Info("It is uplink\n");
 
         struct rte_udp_hdr *udp_header = onvm_pkt_udp_hdr(pkt);
@@ -1077,13 +1000,13 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
         pdr = GetPdrByTeid(pkt, &gtp_info);
 
     } else {
-        // UTLT_Info("It is downlink, dst is %s\n", convertToIpAddress(iph->dst_addr));
+        // UTLT_Info("It is downlink, dst is %s\n", convertToIpAddressString(iph->dst_addr));
         pdr = GetPdrByUeIpAddress(pkt, rte_cpu_to_be_32(iph->dst_addr));
         is_dl = true;
     }
 
     if (!pdr) {
-        UTLT_Error("no PDR found for %s, skip\n", convertToIpAddress(iph->dst_addr));
+        UTLT_Error("no PDR found for %s, skip\n", convertToIpAddressString(iph->dst_addr));
         // TODO(vivek): what to do?
         return 0;
     }
@@ -1093,7 +1016,7 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
         uint32_t ue_key = rte_cpu_to_be_32(iph->dst_addr);
         ue_idx = (int)findIndexByUeIpAddress(ue_key);
         if (ue_idx < 0) {
-            ue_idx = GetQerByUEIpAddressFromPdr(ue_key, pdr, convertToIpAddress(iph->dst_addr));
+            ue_idx = GetQerByUEIpAddressFromPdr(ue_key, pdr, convertToIpAddressString(iph->dst_addr));
         }
     }
 
@@ -1157,8 +1080,17 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
                 Encap(pkt, far, pdr->qer);
         }
 
-        meta->destination = pkt->port ^ 1;
-        AttachL2Header(pkt, true);
+        // meta->destination = pkt->port ^ 1;
+        // AttachL2Header(pkt, true);
+
+        // Regardless of BUFF vs FORW, we need to attach L2 (or ARP) header
+        // before sending to access port.
+        if (attach_l2_or_arp(pkt, g_access_port, g_access_ip_be, g_an_peer_ip_be,
+                            nf_local_ctx->nf) < 0) {
+            meta->action = ONVM_NF_ACTION_DROP;   /* or buffer */
+            return 0;
+        }
+        meta->destination = g_access_port; // DL always goes to access port after FAR processing (may be modified by QoS policing below)
 
         if (far_action == UPDK_FAR_APPLY_ACTION_BUFF) {
             /* Buffer-only: prepare packet for later TX, enqueue, then DROP */
@@ -1248,8 +1180,15 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
         return 0;
     } else {
         /* ── UL: original HandlePacketWithFar path (unchanged) ── */
-        int status = HandlePacketWithFar(pkt, far, pdr->qer, meta);
-        AttachL2Header(pkt, is_dl);
+        int status = HandlePacketWithFar(pkt, far, pdr->qer, g_core_port, meta);
+        // AttachL2Header(pkt, is_dl);
+        if (meta->action == ONVM_NF_ACTION_OUT) {
+            if (attach_l2_or_arp(pkt, g_core_port, g_core_ip_be, g_dn_peer_ip_be,
+                                nf_local_ctx->nf) < 0) {
+                meta->action = ONVM_NF_ACTION_DROP;
+                return 0;
+            }
+        }
         return status;
     }
 }
@@ -1353,8 +1292,11 @@ main(int argc, char *argv[]) {
     if (argc > arg_offset + 1) {
         config_path = argv[arg_offset + 1];
     }
+
     printf("[UPF-U] Using config: %s\n", config_path);
-    UpfU_LoadAndParseConfig(config_path);
+    if (UpfU_LoadAndParseConfig(config_path) != 0) {
+        rte_exit(EXIT_FAILURE, "Failed to load/parse UPF-U YAML config.\n");
+    }
 
     if (UpfClsCtrlInit() < 0) {
         rte_exit(EXIT_FAILURE, "CLS_CTRL memzone init failed\n");
@@ -1364,20 +1306,8 @@ main(int argc, char *argv[]) {
         rte_exit(EXIT_FAILURE, "SESS_BUF memzone init failed\n");
     }
 
-    int ret;
-    ret = rte_eth_macaddr_get(g_access_port, &cn_ue_eth);
-    if (ret < 0)
-        rte_exit(EXIT_FAILURE, "Cannot get MAC address: err=%d, port=%d\n", ret, g_access_port);
-    ret = rte_eth_macaddr_get(g_core_port, &cn_dn_eth);
-    if (ret < 0)
-        rte_exit(EXIT_FAILURE, "Cannot get MAC address: err=%d, port=%d\n", ret, g_core_port);
-
-    /* UTLT_Info("[UPF-U][CONFIG] Port map: ACCESS=%d CORE=%d SGI=%d",
-          g_access_port, g_core_port, g_sgi_port); */
-
-    // 8c:dc:d4:ac:6c:7d
-    memcpy(dn_eth.addr_bytes, DnMac, RTE_ETHER_ADDR_LEN);
-    memcpy(an_eth.addr_bytes, AnMac, RTE_ETHER_ADDR_LEN);
+    // Initialize L2 addresses, must be done after config is loaded (UpfU_LoadAndParseConfig)
+    init_l2_addrs();
 
     // trTCM
     trtcmConfigFlowTables();
@@ -1388,9 +1318,13 @@ main(int argc, char *argv[]) {
     UeIpToUpfSessionMapInit();
     TeidToUpfSessionMapInit();
 
+    /* ARP module init */
+    if (upf_arp_init() < 0) {
+        rte_exit(EXIT_FAILURE, "failed to init ARP module\n");
+    }
+
     onvm_nflib_run(nf_local_ctx);
 
     onvm_nflib_stop(nf_local_ctx);
-    printf("If we reach here, program is ending\n");
     return 0;
 }

--- a/5gc/upf_u/upf_u_arp.c
+++ b/5gc/upf_u/upf_u_arp.c
@@ -24,9 +24,15 @@
 #include "upf_u_arp.h"
 #include "upf_u_config.h"
 #include "upf_u_helper.h"
+#include "utlt_debug.h"
 
-#define ARP_PKTMBUF_POOL_NAME "ARP_pktmbuf_pool"
+#define PKTMBUF_POOL_NAME "MProc_pktmbuf_pool"
 #define NEIGH_TIMEOUT_SEC 300
+
+/* Broadcast MAC address */
+static const struct rte_ether_addr broadcast_mac = {
+    .addr_bytes = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+};
 
 /* ARP Neighbor Table */
 static struct neigh_entry neigh_tbl[NEIGH_MAX];
@@ -45,7 +51,7 @@ is_local_ip_on_port(uint16_t port, uint32_t ip_be) {
 int
 upf_arp_init(void) {
     memset(neigh_tbl, 0, sizeof(neigh_tbl));
-    g_pktmbuf_pool = rte_mempool_lookup(ARP_PKTMBUF_POOL_NAME);
+    g_pktmbuf_pool = rte_mempool_lookup(PKTMBUF_POOL_NAME);
     return (g_pktmbuf_pool != NULL) ? 0 : -1;
 }
 
@@ -151,9 +157,9 @@ send_arp_request(uint16_t port,
         return -1;
 
     if (g_pktmbuf_pool == NULL) {
-        g_pktmbuf_pool = rte_mempool_lookup(ARP_PKTMBUF_POOL_NAME);
+        g_pktmbuf_pool = rte_mempool_lookup(PKTMBUF_POOL_NAME);
         if (g_pktmbuf_pool == NULL) {
-            UTLT_Error("Cannot find mbuf pool %s", ARP_PKTMBUF_POOL_NAME);
+            UTLT_Error("Cannot find mbuf pool %s", PKTMBUF_POOL_NAME);
             return -1;
         }
     }
@@ -179,7 +185,7 @@ send_arp_request(uint16_t port,
 
     /* Ethernet */
     rte_ether_addr_copy(&src_mac, &eth_hdr->src_addr);
-    rte_ether_addr_copy(&rte_ether_broadcast, &eth_hdr->dst_addr);
+    rte_ether_addr_copy(&broadcast_mac, &eth_hdr->dst_addr);
     eth_hdr->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_ARP);
 
     /* ARP request */
@@ -311,9 +317,9 @@ handle_arp_packet(struct rte_mbuf *pkt,
         }
 
         if (g_pktmbuf_pool == NULL) {
-            g_pktmbuf_pool = rte_mempool_lookup(ARP_PKTMBUF_POOL_NAME);
+            g_pktmbuf_pool = rte_mempool_lookup(PKTMBUF_POOL_NAME);
             if (g_pktmbuf_pool == NULL) {
-                UTLT_Error("Cannot find mbuf pool %s", ARP_PKTMBUF_POOL_NAME);
+                UTLT_Error("Cannot find mbuf pool %s", PKTMBUF_POOL_NAME);
                 meta->action = ONVM_NF_ACTION_DROP;
                 return 0;
             }

--- a/5gc/upf_u/upf_u_arp.c
+++ b/5gc/upf_u/upf_u_arp.c
@@ -1,0 +1,426 @@
+/*
+# Copyright 2026 University of California, Riverside and National Yang Ming Chiao Tung University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+*/
+
+#include <string.h>
+#include <rte_cycles.h>
+#include <rte_ethdev.h>
+#include <rte_mempool.h>
+
+#include "upf_u_arp.h"
+#include "upf_u_config.h"
+#include "upf_u_helper.h"
+
+#define ARP_PKTMBUF_POOL_NAME "ARP_pktmbuf_pool"
+#define NEIGH_TIMEOUT_SEC 300
+
+/* ARP Neighbor Table */
+static struct neigh_entry neigh_tbl[NEIGH_MAX];
+
+/* ARP Reply mbuf pool */
+static struct rte_mempool *g_pktmbuf_pool = NULL;
+
+/* Check if the given IP is one of our local IPs on the specified port */
+static int
+is_local_ip_on_port(uint16_t port, uint32_t ip_be) {
+    if (port == g_access_port) return g_access_ip_be == ip_be;
+    if (port == g_core_port)   return g_core_ip_be == ip_be;
+    return 0;
+}
+
+int
+upf_arp_init(void) {
+    memset(neigh_tbl, 0, sizeof(neigh_tbl));
+    g_pktmbuf_pool = rte_mempool_lookup(ARP_PKTMBUF_POOL_NAME);
+    return (g_pktmbuf_pool != NULL) ? 0 : -1;
+}
+
+/* Add UE table entry by UE IP, return 0 on success, -1 on failure */
+static uint32_t
+neigh_hash(uint16_t port, uint32_t ip_be) {
+    return (ip_be ^ ((uint32_t)port << 16) ^ ((uint32_t)port << 3)) % NEIGH_MAX;
+}
+
+/* Lookup neighbor entry by port and IP, return NULL if not found */
+static struct neigh_entry *
+neigh_lookup(uint16_t port, uint32_t ip_be) {
+    uint32_t start = neigh_hash(port, ip_be);
+    uint32_t idx = start;
+
+    do {
+        struct neigh_entry *e = &neigh_tbl[idx];
+
+        if (!e->in_use) {
+            return NULL;   /* linear probing stop */
+        }
+
+        if (e->port_id == port && e->ip_be == ip_be) {
+            /* Optional stale marking */
+            uint64_t now = rte_get_tsc_cycles();
+            uint64_t hz = rte_get_tsc_hz();
+            if (e->state == NEIGH_REACHABLE &&
+                hz > 0 &&
+                now - e->last_update_tsc > (uint64_t)NEIGH_TIMEOUT_SEC * hz) {
+                e->state = NEIGH_STALE;
+            }
+            return e;
+        }
+
+        idx = (idx + 1) % NEIGH_MAX;
+    } while (idx != start);
+
+    return NULL;
+}
+
+/* Update neighbor entry */
+static void
+neigh_update(uint16_t port, uint32_t ip_be, const struct rte_ether_addr *mac) {
+    if (mac == NULL)
+        return;
+
+    uint32_t start = neigh_hash(port, ip_be);
+    uint32_t idx = start;
+    struct neigh_entry *free_slot = NULL;
+
+    do {
+        struct neigh_entry *e = &neigh_tbl[idx];
+
+        if (!e->in_use) {
+            free_slot = e;
+            break;
+        }
+
+        if (e->port_id == port && e->ip_be == ip_be) {
+            rte_ether_addr_copy(mac, &e->mac);
+            e->last_update_tsc = rte_get_tsc_cycles();
+            e->state = NEIGH_REACHABLE;
+            return;
+        }
+
+        idx = (idx + 1) % NEIGH_MAX;
+    } while (idx != start);
+
+    if (free_slot) {
+        free_slot->in_use = 1;
+        free_slot->port_id = port;
+        free_slot->ip_be = ip_be;
+        rte_ether_addr_copy(mac, &free_slot->mac);
+        free_slot->last_update_tsc = rte_get_tsc_cycles();
+        free_slot->state = NEIGH_REACHABLE;
+        return;
+    }
+
+    /* Table full: simple replacement policy */
+    idx = start;
+    neigh_tbl[idx].in_use = 1;
+    neigh_tbl[idx].port_id = port;
+    neigh_tbl[idx].ip_be = ip_be;
+    rte_ether_addr_copy(mac, &neigh_tbl[idx].mac);
+    neigh_tbl[idx].last_update_tsc = rte_get_tsc_cycles();
+    neigh_tbl[idx].state = NEIGH_REACHABLE;
+}
+
+/* Lookup neighbor MAC by port and IP, returns NULL if not found or stale */
+static int
+send_arp_request(uint16_t port,
+                 uint32_t sip_be,
+                 uint32_t tip_be,
+                 struct onvm_nf *nf) {
+    struct rte_mbuf *out_pkt = NULL;
+    struct onvm_pkt_meta *pmeta = NULL;
+    struct rte_ether_hdr *eth_hdr = NULL;
+    struct rte_arp_hdr *arp_hdr = NULL;
+    struct rte_ether_addr src_mac;
+    size_t pkt_size;
+
+    if (nf == NULL)
+        return -1;
+
+    if (g_pktmbuf_pool == NULL) {
+        g_pktmbuf_pool = rte_mempool_lookup(ARP_PKTMBUF_POOL_NAME);
+        if (g_pktmbuf_pool == NULL) {
+            UTLT_Error("Cannot find mbuf pool %s", ARP_PKTMBUF_POOL_NAME);
+            return -1;
+        }
+    }
+
+    if (rte_eth_macaddr_get(port, &src_mac) < 0) {
+        UTLT_Error("Failed to get MAC for port %u", port);
+        return -1;
+    }
+
+    out_pkt = rte_pktmbuf_alloc(g_pktmbuf_pool);
+    if (out_pkt == NULL)
+        return -1;
+
+    pkt_size = sizeof(struct rte_ether_hdr) + sizeof(struct rte_arp_hdr);
+    char *data = rte_pktmbuf_append(out_pkt, pkt_size);
+    if (data == NULL) {
+        rte_pktmbuf_free(out_pkt);
+        return -1;
+    }
+
+    eth_hdr = (struct rte_ether_hdr *)data;
+    arp_hdr = (struct rte_arp_hdr *)(eth_hdr + 1);
+
+    /* Ethernet */
+    rte_ether_addr_copy(&src_mac, &eth_hdr->src_addr);
+    rte_ether_addr_copy(&rte_ether_broadcast, &eth_hdr->dst_addr);
+    eth_hdr->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_ARP);
+
+    /* ARP request */
+    arp_hdr->arp_hardware = rte_cpu_to_be_16(RTE_ARP_HRD_ETHER);
+    arp_hdr->arp_protocol = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4);
+    arp_hdr->arp_hlen = RTE_ETHER_ADDR_LEN;
+    arp_hdr->arp_plen = sizeof(uint32_t);
+    arp_hdr->arp_opcode = rte_cpu_to_be_16(RTE_ARP_OP_REQUEST);
+
+    rte_ether_addr_copy(&src_mac, &arp_hdr->arp_data.arp_sha);
+    arp_hdr->arp_data.arp_sip = sip_be;
+
+    memset(&arp_hdr->arp_data.arp_tha, 0, sizeof(struct rte_ether_addr));
+    arp_hdr->arp_data.arp_tip = tip_be;
+
+    /* Mark neighbor INCOMPLETE if not already there */
+    struct neigh_entry *e = neigh_lookup(port, tip_be);
+    if (e == NULL) {
+        uint32_t start = neigh_hash(port, tip_be);
+        uint32_t idx = start;
+        do {
+            if (!neigh_tbl[idx].in_use) {
+                neigh_tbl[idx].in_use = 1;
+                neigh_tbl[idx].port_id = port;
+                neigh_tbl[idx].ip_be = tip_be;
+                memset(&neigh_tbl[idx].mac, 0, sizeof(struct rte_ether_addr));
+                neigh_tbl[idx].last_update_tsc = rte_get_tsc_cycles();
+                neigh_tbl[idx].state = NEIGH_INCOMPLETE;
+                break;
+            }
+            idx = (idx + 1) % NEIGH_MAX;
+        } while (idx != start);
+    } else if (e->state == NEIGH_STALE) {
+        e->state = NEIGH_INCOMPLETE;
+        e->last_update_tsc = rte_get_tsc_cycles();
+    }
+
+    pmeta = onvm_get_pkt_meta(out_pkt, nf->dynfield_offset);
+    pmeta->destination = port;
+    pmeta->action = ONVM_NF_ACTION_OUT;
+
+    return onvm_nflib_return_pkt(nf, out_pkt);
+}
+
+/* Handle incoming ARP packets, send reply if it's a request for our IP */
+int
+handle_arp_packet(struct rte_mbuf *pkt,
+                  struct onvm_pkt_meta *meta,
+                  struct onvm_nf_local_ctx *ctx) {
+    struct rte_ether_hdr *eth_hdr = NULL;
+    struct rte_arp_hdr *arp_hdr = NULL;
+    struct rte_ether_addr local_mac;
+    uint16_t op;
+    uint16_t port;
+    uint32_t target_ip_be;
+    uint32_t sender_ip_be;
+
+    if (pkt == NULL || meta == NULL || ctx == NULL || ctx->nf == NULL) {
+        UTLT_Error("handle_arp_packet: invalid input pkt=%p meta=%p ctx=%p nf=%p",
+               pkt, meta, ctx, (ctx ? ctx->nf : NULL));
+        return 0;
+    }
+
+    if (pkt->pkt_len < sizeof(struct rte_ether_hdr) + sizeof(struct rte_arp_hdr)) {
+        UTLT_Debug("handle_arp_packet: short ARP packet len=%u port=%u",
+               pkt->pkt_len, pkt->port);
+        meta->action = ONVM_NF_ACTION_DROP;
+        return 0;
+    }
+
+    eth_hdr = onvm_pkt_ether_hdr(pkt);
+    if (eth_hdr == NULL) {
+        UTLT_Warning("handle_arp_packet: failed to get ethernet header, len=%u port=%u",
+                 pkt->pkt_len, pkt->port);
+        meta->action = ONVM_NF_ACTION_DROP;
+        return 0;
+    }
+
+    if (rte_be_to_cpu_16(eth_hdr->ether_type) != RTE_ETHER_TYPE_ARP) {
+        meta->action = ONVM_NF_ACTION_DROP;
+        return 0;
+    }
+
+    arp_hdr = rte_pktmbuf_mtod_offset(pkt, struct rte_arp_hdr *,
+                                      sizeof(struct rte_ether_hdr));
+    if (arp_hdr == NULL) {
+        UTLT_Warning("handle_arp_packet: failed to get ARP header, len=%u port=%u",
+                 pkt->pkt_len, pkt->port);
+        meta->action = ONVM_NF_ACTION_DROP;
+        return 0;
+    }
+
+    /* Basic sanity */
+    if (rte_be_to_cpu_16(arp_hdr->arp_hardware) != RTE_ARP_HRD_ETHER ||
+        rte_be_to_cpu_16(arp_hdr->arp_protocol) != RTE_ETHER_TYPE_IPV4 ||
+        arp_hdr->arp_hlen != RTE_ETHER_ADDR_LEN ||
+        arp_hdr->arp_plen != sizeof(uint32_t)) {
+        UTLT_Debug("handle_arp_packet: invalid ARP hdr port=%u hrd=%u pro=0x%04x hlen=%u plen=%u",
+               pkt->port,
+               rte_be_to_cpu_16(arp_hdr->arp_hardware),
+               rte_be_to_cpu_16(arp_hdr->arp_protocol),
+               arp_hdr->arp_hlen,
+               arp_hdr->arp_plen);
+        meta->action = ONVM_NF_ACTION_DROP;
+        return 0;
+    }
+
+    port = pkt->port;
+    op = rte_be_to_cpu_16(arp_hdr->arp_opcode);
+    sender_ip_be = arp_hdr->arp_data.arp_sip;
+    target_ip_be = arp_hdr->arp_data.arp_tip;
+
+    /* Learn sender on both request and reply */
+    neigh_update(port, sender_ip_be, &arp_hdr->arp_data.arp_sha);
+
+    switch (op) {
+    case RTE_ARP_OP_REQUEST: {
+        if (!is_local_ip_on_port(port, target_ip_be)) {
+            UTLT_Debug("handle_arp_packet: ARP request not for local IP, port=%u target_ip=%s",
+               port, convertToIpAddressString(target_ip_be));
+            meta->action = ONVM_NF_ACTION_DROP;
+            return 0;
+        }
+
+        if (rte_eth_macaddr_get(port, &local_mac) < 0) {
+            UTLT_Error("handle_arp_packet: failed to get local MAC for port=%u", port);
+            meta->action = ONVM_NF_ACTION_DROP;
+            return 0;
+        }
+
+        if (g_pktmbuf_pool == NULL) {
+            g_pktmbuf_pool = rte_mempool_lookup(ARP_PKTMBUF_POOL_NAME);
+            if (g_pktmbuf_pool == NULL) {
+                UTLT_Error("Cannot find mbuf pool %s", ARP_PKTMBUF_POOL_NAME);
+                meta->action = ONVM_NF_ACTION_DROP;
+                return 0;
+            }
+        }
+
+        /* Build and send ARP reply */
+        struct rte_mbuf *out_pkt = rte_pktmbuf_alloc(g_pktmbuf_pool);
+        if (out_pkt == NULL) {
+            meta->action = ONVM_NF_ACTION_DROP;
+            return 0;
+        }
+
+        size_t pkt_size = sizeof(struct rte_ether_hdr) + sizeof(struct rte_arp_hdr);
+        char *data = rte_pktmbuf_append(out_pkt, pkt_size);
+        if (data == NULL) {
+            rte_pktmbuf_free(out_pkt);
+            meta->action = ONVM_NF_ACTION_DROP;
+            return 0;
+        }
+
+        struct rte_ether_hdr *out_eth = (struct rte_ether_hdr *)data;
+        struct rte_arp_hdr *out_arp = (struct rte_arp_hdr *)(out_eth + 1);
+
+        /* Ethernet */
+        rte_ether_addr_copy(&local_mac, &out_eth->src_addr);
+        rte_ether_addr_copy(&arp_hdr->arp_data.arp_sha, &out_eth->dst_addr);
+        out_eth->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_ARP);
+
+        /* ARP reply */
+        out_arp->arp_hardware = rte_cpu_to_be_16(RTE_ARP_HRD_ETHER);
+        out_arp->arp_protocol = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4);
+        out_arp->arp_hlen = RTE_ETHER_ADDR_LEN;
+        out_arp->arp_plen = sizeof(uint32_t);
+        out_arp->arp_opcode = rte_cpu_to_be_16(RTE_ARP_OP_REPLY);
+
+        /* sender = me */
+        rte_ether_addr_copy(&local_mac, &out_arp->arp_data.arp_sha);
+        out_arp->arp_data.arp_sip = target_ip_be;
+
+        /* target = original requester */
+        rte_ether_addr_copy(&arp_hdr->arp_data.arp_sha, &out_arp->arp_data.arp_tha);
+        out_arp->arp_data.arp_tip = sender_ip_be;
+
+        struct onvm_pkt_meta *pmeta =
+            onvm_get_pkt_meta(out_pkt, ctx->nf->dynfield_offset);
+        pmeta->destination = port;
+        pmeta->action = ONVM_NF_ACTION_OUT;
+
+        int rc = onvm_nflib_return_pkt(ctx->nf, out_pkt);
+        if (rc < 0) {
+            char sip_buf[16], tip_buf[16];
+            UTLT_Warning("handle_arp_packet: failed to send ARP reply on port=%u rc=%d sip=%s tip=%s",
+                        port, rc,
+                        ipv4_to_buf(out_arp->arp_data.arp_sip, sip_buf),
+                        ipv4_to_buf(out_arp->arp_data.arp_tip, tip_buf));
+        } else {
+            char sip_buf[16], tip_buf[16];
+            UTLT_Trace("handle_arp_packet: sent ARP reply on port=%u sip=%s tip=%s",
+                        port,
+                        ipv4_to_buf(out_arp->arp_data.arp_sip, sip_buf),
+                        ipv4_to_buf(out_arp->arp_data.arp_tip, tip_buf));
+        }
+
+        // This ARP Request packet is consumed by us, no need to pass to other NFs
+        meta->action = ONVM_NF_ACTION_DROP;
+        return 0;
+    }
+
+    case RTE_ARP_OP_REPLY:
+        /* already learned above */
+        meta->action = ONVM_NF_ACTION_DROP;
+        return 0;
+
+    default:
+        meta->action = ONVM_NF_ACTION_DROP;
+        return 0;
+    }
+}
+
+/* Attach L2 header or send ARP request if next-hop MAC unknown */
+int
+attach_l2_or_arp(struct rte_mbuf *pkt,
+                 uint16_t out_port,
+                 uint32_t local_ip_be,
+                 uint32_t next_hop_ip_be,
+                 struct onvm_nf *nf) {
+    struct rte_ether_hdr *eth_hdr;
+    struct neigh_entry *ne;
+    struct rte_ether_addr local_mac;
+
+    ne = neigh_lookup(out_port, next_hop_ip_be);
+    if (ne == NULL || ne->state != NEIGH_REACHABLE) {
+        (void)send_arp_request(out_port, local_ip_be, next_hop_ip_be, nf);
+        return -1;
+    }
+
+    eth_hdr = (struct rte_ether_hdr *)
+        rte_pktmbuf_prepend(pkt, sizeof(struct rte_ether_hdr));
+    if (eth_hdr == NULL)
+        return -1;
+
+    if (rte_eth_macaddr_get(out_port, &local_mac) < 0)
+        return -1;
+
+    rte_ether_addr_copy(&local_mac, &eth_hdr->src_addr);
+    rte_ether_addr_copy(&ne->mac, &eth_hdr->dst_addr);
+    eth_hdr->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4);
+
+    return 0;
+}

--- a/5gc/upf_u/upf_u_arp.h
+++ b/5gc/upf_u/upf_u_arp.h
@@ -1,0 +1,62 @@
+/*
+# Copyright 2026 University of California, Riverside and National Yang Ming Chiao Tung University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+*/
+
+#ifndef UPF_U_ARP_H
+#define UPF_U_ARP_H
+
+#include <stdint.h>
+#include <rte_arp.h>
+#include <rte_ether.h>
+#include <rte_mbuf.h>
+
+#include "onvm_nflib.h"
+
+#define NEIGH_MAX 64
+
+enum neigh_state {
+    NEIGH_EMPTY = 0,
+    NEIGH_INCOMPLETE,
+    NEIGH_REACHABLE,
+    NEIGH_STALE,
+};
+
+struct neigh_entry {
+    uint32_t ip_be;                 /* next-hop IP, network byte order */
+    uint16_t port_id;               /* egress port */
+    struct rte_ether_addr mac;
+    uint64_t last_update_tsc;
+    uint8_t state;
+    uint8_t in_use;
+};
+
+int
+upf_arp_init(void);
+
+int
+handle_arp_packet(struct rte_mbuf *pkt,
+                  struct onvm_pkt_meta *meta,
+                  struct onvm_nf_local_ctx *ctx);
+
+int
+attach_l2_or_arp(struct rte_mbuf *pkt,
+                 uint16_t out_port,
+                 uint32_t local_ip_be,
+                 uint32_t next_hop_ip_be,
+                 struct onvm_nf *nf);
+
+#endif

--- a/5gc/upf_u/upf_u_config.c
+++ b/5gc/upf_u/upf_u_config.c
@@ -16,19 +16,15 @@
 # SPDX-License-Identifier: Apache-2.0
 */
 
-#include "upf_u_config.h"
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 #include <yaml.h>
 
-uint8_t  g_dn_mac[RTE_ETHER_ADDR_LEN];
-uint8_t  g_an_mac[RTE_ETHER_ADDR_LEN];
+#include "upf_u_config.h"
+#include "utlt_debug.h"
 
-struct rte_ether_addr g_an_eth;
-struct rte_ether_addr g_dn_eth;
 struct rte_ether_addr g_cn_ue_eth;
 struct rte_ether_addr g_cn_dn_eth;
 
@@ -41,6 +37,7 @@ uint32_t g_core_ip_be   = 0;
 uint32_t g_an_peer_ip_be = 0;
 uint32_t g_dn_peer_ip_be = 0;
 
+char g_log_level[16] = "warning";
 
 static int
 parse_mac(const char *input_string, uint8_t out_mac_addr[6]) {
@@ -116,29 +113,23 @@ do_parse(yaml_document_t *doc) {
     if (!cfg || cfg->type != YAML_MAPPING_NODE)
         return -1;
 
+    // log_level (optional)
+    {
+        yaml_node_t *n = map_get(doc, cfg, "log_level");
+        const char *s = scalar_str(n);
+
+        if (s && *s) {
+            size_t len = strlen(s);
+            if (len >= sizeof(g_log_level))
+                len = sizeof(g_log_level) - 1;
+            memcpy(g_log_level, s, len);
+            g_log_level[len] = '\0';
+        }
+    }
+
     yaml_node_t *dp   = map_get(doc, cfg,  "dataplane");
     if (!dp || dp->type != YAML_MAPPING_NODE)
         return -1;
-
-    // dn_mac
-    {
-        yaml_node_t *n = map_get(doc, dp, "dn_mac");
-        const char *s = scalar_str(n);
-        if (!s || parse_mac(s, g_dn_mac) != 0) {
-            fprintf(stderr, "[UPF-U][CONFIG] invalid dn_mac\n");
-            return -1;
-        }
-    }
-
-    // an_mac
-    {
-        yaml_node_t *n = map_get(doc, dp, "an_mac");
-        const char *s = scalar_str(n);
-        if (!s || parse_mac(s, g_an_mac) != 0) {
-            fprintf(stderr, "[UPF-U][CONFIG] invalid an_mac\n");
-            return -1;
-        }
-    }
 
     // upf_access_ip
     {
@@ -306,10 +297,4 @@ init_l2_addrs(void) {
                  "Cannot get MAC address: err=%d, port=%" PRIu16 "\n",
                  ret, g_core_port);
     }
-
-    /* UTLT_Info("[UPF-U][CONFIG] Port map: ACCESS=%" PRIu16 " CORE=%" PRIu16 " SGI=%" PRIu16 ",",
-          g_access_port, g_core_port, g_sgi_port); */
-
-    memcpy(g_dn_eth.addr_bytes, g_dn_mac, RTE_ETHER_ADDR_LEN);
-    memcpy(g_an_eth.addr_bytes, g_an_mac, RTE_ETHER_ADDR_LEN);
 }

--- a/5gc/upf_u/upf_u_config.c
+++ b/5gc/upf_u/upf_u_config.c
@@ -1,3 +1,21 @@
+/*
+# Copyright 2026 University of California, Riverside and National Yang Ming Chiao Tung University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+*/
+
 #include "upf_u_config.h"
 
 #include <stdio.h>
@@ -6,39 +24,65 @@
 #include <ctype.h>
 #include <yaml.h>
 
-extern uint8_t  DnMac[6];
-extern uint8_t  AnMac[6];
-extern uint32_t SELF_IP;
-extern int16_t  g_access_port;
-extern int16_t  g_core_port;
-extern int16_t  g_sgi_port;
+uint8_t  g_dn_mac[RTE_ETHER_ADDR_LEN];
+uint8_t  g_an_mac[RTE_ETHER_ADDR_LEN];
+
+struct rte_ether_addr g_an_eth;
+struct rte_ether_addr g_dn_eth;
+struct rte_ether_addr g_cn_ue_eth;
+struct rte_ether_addr g_cn_dn_eth;
+
+uint16_t g_access_port = 0;
+uint16_t g_core_port   = 0;
+uint16_t g_sgi_port    = 0;
+
+uint32_t g_access_ip_be = 0;
+uint32_t g_core_ip_be   = 0;
+uint32_t g_an_peer_ip_be = 0;
+uint32_t g_dn_peer_ip_be = 0;
 
 
-static void fatal(const char *msg) {
-    fprintf(stderr, "[UPF-U][CONFIG] %s\n", msg);
-    exit(EXIT_FAILURE);
-}
-
-static int parse_mac(const char *txt, uint8_t out[6]) {
+static int
+parse_mac(const char *input_string, uint8_t out_mac_addr[6]) {
     int v[6];
-    if (sscanf(txt, " %x:%x:%x:%x:%x:%x ", &v[0],&v[1],&v[2],&v[3],&v[4],&v[5]) != 6) return -1;
-    for (int i=0;i<6;i++) out[i] = (uint8_t)v[i];
+    if (sscanf(input_string, " %x:%x:%x:%x:%x:%x ", &v[0],&v[1],&v[2],&v[3],&v[4],&v[5]) != 6) return -1;
+    for (int i = 0; i < 6; i++) out_mac_addr[i] = (uint8_t)v[i];
     return 0;
 }
 
+static int
+parse_ipv4_address(const char *addrStr, uint32_t *out_ip_be) {
+    const char *p = addrStr;
+    char *endp;
 
-int parseIpv4Address(const char *s);
+    unsigned long a = strtoul(p, &endp, 10);
+    if (*endp != '.')
+        return -1;
+    unsigned long b = strtoul(p = endp + 1, &endp, 10);
+    if (*endp != '.')
+        return -1;
+    unsigned long c = strtoul(p = endp + 1, &endp, 10);
+    if (*endp != '.')
+        return -1;
+    unsigned long d = strtoul(p = endp + 1, &endp, 10);
+
+    *out_ip_be = (uint32_t)((d << 24) | (c << 16) | (b << 8) | a);
+    UTLT_Info("IP Address: %s -> %d\n", addrStr, *out_ip_be);
+    return 0;
+}
 
 // --- libyaml DOM helpers ---
 
-static yaml_node_t* doc_root(yaml_document_t *doc) {
+static yaml_node_t*
+doc_root(yaml_document_t *doc) {
     // The first (and only) document's root is node id 1 for libyaml DOM
     if (!doc || doc->nodes.top <= doc->nodes.start) return NULL;
     return yaml_document_get_root_node(doc);
 }
 
 // Look up a mapping value by 'key' string. Returns the value node or NULL.
-static yaml_node_t* map_get(yaml_document_t *doc, yaml_node_t *map, const char *key) {
+static yaml_node_t*
+map_get(yaml_document_t *doc, yaml_node_t *map, const char *key) {
     if (!map || map->type != YAML_MAPPING_NODE) return NULL;
     for (yaml_node_pair_t *p = map->data.mapping.pairs.start;
          p < map->data.mapping.pairs.top; ++p) {
@@ -51,14 +95,16 @@ static yaml_node_t* map_get(yaml_document_t *doc, yaml_node_t *map, const char *
     return NULL;
 }
 
-static const char* scalar_str(yaml_node_t *n) {
+static const char*
+scalar_str(yaml_node_t *n) {
     if (!n || n->type != YAML_SCALAR_NODE) return NULL;
     return (const char*)n->data.scalar.value;
 }
 
 // --- Parse logic: configuration -> dataplane -> fields ---
 
-static int do_parse(yaml_document_t *doc) {
+static int
+do_parse(yaml_document_t *doc) {
     yaml_node_t *root = doc_root(doc);
     if (!root || root->type != YAML_MAPPING_NODE)
         return -1;
@@ -78,7 +124,7 @@ static int do_parse(yaml_document_t *doc) {
     {
         yaml_node_t *n = map_get(doc, dp, "dn_mac");
         const char *s = scalar_str(n);
-        if (!s || parse_mac(s, DnMac) != 0) {
+        if (!s || parse_mac(s, g_dn_mac) != 0) {
             fprintf(stderr, "[UPF-U][CONFIG] invalid dn_mac\n");
             return -1;
         }
@@ -88,17 +134,17 @@ static int do_parse(yaml_document_t *doc) {
     {
         yaml_node_t *n = map_get(doc, dp, "an_mac");
         const char *s = scalar_str(n);
-        if (!s || parse_mac(s, AnMac) != 0) {
+        if (!s || parse_mac(s, g_an_mac) != 0) {
             fprintf(stderr, "[UPF-U][CONFIG] invalid an_mac\n");
             return -1;
         }
     }
 
-    // upf_ip
+    // upf_access_ip
     {
-        yaml_node_t *n = map_get(doc, dp, "upf_ip");
+        yaml_node_t *n = map_get(doc, dp, "upf_access_ip");
         if (!n || n->type != YAML_SCALAR_NODE) {
-            fprintf(stderr, "[UPF-U][CONFIG] missing upf_ip\n");
+            fprintf(stderr, "[UPF-U][CONFIG] missing upf_access_ip\n");
             return -1;
         }
         const unsigned char *p = n->data.scalar.value;
@@ -109,13 +155,76 @@ static int do_parse(yaml_document_t *doc) {
         memcpy(buf, p, len);
         buf[len] = '\0';
 
-        if (parseIpv4Address(buf)) {
-            fprintf(stderr, "[UPF-U][CONFIG] invalid upf_ip\n");
+        if (parse_ipv4_address(buf, &g_access_ip_be) != 0) {
+            fprintf(stderr, "[UPF-U][CONFIG] invalid upf_access_ip\n");
             return -1;
         }
     }
 
-    // dataplane.ports
+    // upf_core_ip
+    {
+        yaml_node_t *n = map_get(doc, dp, "upf_core_ip");
+        if (!n || n->type != YAML_SCALAR_NODE) {
+            fprintf(stderr, "[UPF-U][CONFIG] missing upf_core_ip\n");
+            return -1;
+        }
+        const unsigned char *p = n->data.scalar.value;
+        size_t len = n->data.scalar.length;
+
+        char buf[64];
+        if (len >= sizeof(buf)) len = sizeof(buf) - 1;
+        memcpy(buf, p, len);
+        buf[len] = '\0';
+
+        if (parse_ipv4_address(buf, &g_core_ip_be) != 0) {
+            fprintf(stderr, "[UPF-U][CONFIG] invalid upf_core_ip\n");
+            return -1;
+        }
+    }
+
+    // an_peer_ip
+    {
+        yaml_node_t *n = map_get(doc, dp, "an_peer_ip");
+        if (!n || n->type != YAML_SCALAR_NODE) {
+            fprintf(stderr, "[UPF-U][CONFIG] missing an_peer_ip\n");
+            return -1;
+        }
+        const unsigned char *p = n->data.scalar.value;
+        size_t len = n->data.scalar.length;
+
+        char buf[64];
+        if (len >= sizeof(buf)) len = sizeof(buf) - 1;
+        memcpy(buf, p, len);
+        buf[len] = '\0';
+
+        if (parse_ipv4_address(buf, &g_an_peer_ip_be) != 0) {
+            fprintf(stderr, "[UPF-U][CONFIG] invalid an_peer_ip\n");
+            return -1;
+        }
+    }
+
+    // dn_peer_ip
+    {
+        yaml_node_t *n = map_get(doc, dp, "dn_peer_ip");
+        if (!n || n->type != YAML_SCALAR_NODE) {
+            fprintf(stderr, "[UPF-U][CONFIG] missing dn_peer_ip\n");
+            return -1;
+        }
+        const unsigned char *p = n->data.scalar.value;
+        size_t len = n->data.scalar.length;
+
+        char buf[64];
+        if (len >= sizeof(buf)) len = sizeof(buf) - 1;
+        memcpy(buf, p, len);
+        buf[len] = '\0';
+
+        if (parse_ipv4_address(buf, &g_dn_peer_ip_be) != 0) {
+            fprintf(stderr, "[UPF-U][CONFIG] invalid dn_peer_ip\n");
+            return -1;
+        }
+    }
+
+    // ports
     {
         yaml_node_t *ports = map_get(doc, dp, "ports");
         if (!ports || ports->type != YAML_MAPPING_NODE) {
@@ -129,7 +238,7 @@ static int do_parse(yaml_document_t *doc) {
             if (!s) { fprintf(stderr, "[UPF-U][CONFIG] missing ports.access\n"); return -1; }
             int v = atoi(s);
             if (v < 0 || v > 255) { fprintf(stderr, "[UPF-U][CONFIG] bad ports.access\n"); return -1; }
-            g_access_port = (int16_t)v;
+            g_access_port = (uint16_t)v;
         }
         // core  (SGi follows CORE)
         {
@@ -138,15 +247,16 @@ static int do_parse(yaml_document_t *doc) {
             if (!s) { fprintf(stderr, "[UPF-U][CONFIG] missing ports.core\n"); return -1; }
             int v = atoi(s);
             if (v < 0 || v > 255) { fprintf(stderr, "[UPF-U][CONFIG] bad ports.core\n"); return -1; }
-            g_core_port = (int16_t)v;
-            g_sgi_port  = (int16_t)v;
+            g_core_port = (uint16_t)v;
+            g_sgi_port  = (uint16_t)v;
         }
     }
 
     return 0;
 }
 
-int UpfU_TryLoadAndParseConfig(const char *path) {
+int
+UpfU_LoadAndParseConfig(const char *path) {
     FILE *fp = fopen(path, "rb");
     if (!fp) {
         fprintf(stderr, "[UPF-U][CONFIG] cannot open config file: %s\n", path);
@@ -179,8 +289,27 @@ int UpfU_TryLoadAndParseConfig(const char *path) {
     return rc == 0 ? 0 : -1;
 }
 
-void UpfU_LoadAndParseConfig(const char *path) {
-    if (UpfU_TryLoadAndParseConfig(path) != 0) {
-        fatal("Failed to load/parse UPF-U YAML config.");
+void
+init_l2_addrs(void) {
+    int ret;
+
+    ret = rte_eth_macaddr_get(g_access_port, &g_cn_ue_eth);
+    if (ret < 0) {
+        rte_exit(EXIT_FAILURE,
+                 "Cannot get MAC address: err=%d, port=%" PRIu16 "\n",
+                 ret, g_access_port);
     }
+
+    ret = rte_eth_macaddr_get(g_core_port, &g_cn_dn_eth);
+    if (ret < 0) {
+        rte_exit(EXIT_FAILURE,
+                 "Cannot get MAC address: err=%d, port=%" PRIu16 "\n",
+                 ret, g_core_port);
+    }
+
+    /* UTLT_Info("[UPF-U][CONFIG] Port map: ACCESS=%" PRIu16 " CORE=%" PRIu16 " SGI=%" PRIu16 ",",
+          g_access_port, g_core_port, g_sgi_port); */
+
+    memcpy(g_dn_eth.addr_bytes, g_dn_mac, RTE_ETHER_ADDR_LEN);
+    memcpy(g_an_eth.addr_bytes, g_an_mac, RTE_ETHER_ADDR_LEN);
 }

--- a/5gc/upf_u/upf_u_config.h
+++ b/5gc/upf_u/upf_u_config.h
@@ -1,7 +1,49 @@
-#pragma once
+/*
+# Copyright 2026 University of California, Riverside and National Yang Ming Chiao Tung University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+*/
+
+#ifndef UPF_U_CONFIG_H
+#define UPF_U_CONFIG_H
+
 #include <stdint.h>
+#include <rte_ether.h>
 
+extern uint32_t g_access_ip_be;   // UPF local IP on the access-facing port
+extern uint32_t g_core_ip_be;     // UPF local IP on the core/SGi-facing port
 
-void UpfU_LoadAndParseConfig(const char *path);
+extern uint32_t g_an_peer_ip_be;  // Next-hop IP of the AN/gNB peer
+extern uint32_t g_dn_peer_ip_be;  // Next-hop IP of the DN/upstream router peer
 
-int UpfU_TryLoadAndParseConfig(const char *path);
+extern uint16_t  g_access_port;    // UPF-U DPDK port connected to the access side (AN/gNB)
+extern uint16_t  g_core_port;      // UPF-U DPDK port connected to the core side (SGi)
+extern uint16_t  g_sgi_port;       // UPF-U DPDK port connected to the SGi side
+
+extern uint8_t  g_an_mac[RTE_ETHER_ADDR_LEN];       // MAC address of the AN peer (e.g., gNB)
+extern uint8_t  g_dn_mac[RTE_ETHER_ADDR_LEN];       // MAC address of the DN peer (e.g., upstream router or DN server)
+
+extern struct rte_ether_addr g_an_eth;     // Ethernet address for AN peer
+extern struct rte_ether_addr g_dn_eth;     // Ethernet address for DN peer
+extern struct rte_ether_addr g_cn_ue_eth;  // Ethernet address for access-facing side of UPF (used when sending to UE)
+extern struct rte_ether_addr g_cn_dn_eth;  // Ethernet address for core-facing side of UPF (used when sending to DN)
+
+int
+UpfU_LoadAndParseConfig(const char *path);
+
+void
+init_l2_addrs(void);
+
+#endif

--- a/5gc/upf_u/upf_u_config.h
+++ b/5gc/upf_u/upf_u_config.h
@@ -32,13 +32,10 @@ extern uint16_t  g_access_port;    // UPF-U DPDK port connected to the access si
 extern uint16_t  g_core_port;      // UPF-U DPDK port connected to the core side (SGi)
 extern uint16_t  g_sgi_port;       // UPF-U DPDK port connected to the SGi side
 
-extern uint8_t  g_an_mac[RTE_ETHER_ADDR_LEN];       // MAC address of the AN peer (e.g., gNB)
-extern uint8_t  g_dn_mac[RTE_ETHER_ADDR_LEN];       // MAC address of the DN peer (e.g., upstream router or DN server)
-
-extern struct rte_ether_addr g_an_eth;     // Ethernet address for AN peer
-extern struct rte_ether_addr g_dn_eth;     // Ethernet address for DN peer
 extern struct rte_ether_addr g_cn_ue_eth;  // Ethernet address for access-facing side of UPF (used when sending to UE)
 extern struct rte_ether_addr g_cn_dn_eth;  // Ethernet address for core-facing side of UPF (used when sending to DN)
+
+extern char g_log_level[16]; // Log level for UPF-U (e.g., "trace", "debug", "info", "warning", "error")
 
 int
 UpfU_LoadAndParseConfig(const char *path);

--- a/5gc/upf_u/upf_u_helper.c
+++ b/5gc/upf_u/upf_u_helper.c
@@ -1,0 +1,72 @@
+/*
+# Copyright 2026 University of California, Riverside and National Yang Ming Chiao Tung University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+*/
+
+#include "upf_u_helper.h"
+
+#define IP_MASKED(BIGENDIINT, LEN) (BIGENDIINT & (0xFFFFFFFF << (32-LEN)))
+
+const char *
+ipv4_to_buf(uint32_t be_addr, char buf[16]) {
+    inet_ntop(AF_INET, &be_addr, buf, 16);
+    return buf;
+}
+
+void
+dump_gtpu(const uint8_t *start, size_t len, size_t gtp_off) {
+    printf("---- GTPU Dump (offset %zu, %zu bytes) ----\n", gtp_off, len);
+    for (size_t i = 0; i < len; i++) {
+        if (i % 16 == 0) printf("\n%04zu : ", i);
+        printf("%02x ", start[i]);
+    }
+    printf("\n------------------------------------------\n");
+}
+
+const char*
+ip4(uint32_t host_ip) {
+    static char buf[16];
+    struct in_addr a = { .s_addr = htonl(host_ip) };
+    return inet_ntop(AF_INET, &a, buf, sizeof(buf)) ? buf : "<err>";
+}
+
+uint32_t
+charStr2MaskedIP(char *str, uint32_t *prefix_val) {
+    char ip_str[INET_ADDRSTRLEN];
+    uint32_t prefix_len, subnet;
+
+    sscanf(str, "%[^/]/%d", ip_str, &prefix_len);
+    struct in_addr ip_addr;
+    inet_pton(AF_INET, ip_str, &ip_addr);
+
+    if (prefix_val) *prefix_val = prefix_len;
+    return IP_MASKED(ip_addr.s_addr, prefix_len);
+}
+
+char *
+convertToIpAddressString(uint32_t big_endian_value) {
+    static char ip_string[16];
+
+    uint8_t ip_address[4];
+    ip_address[0] = (big_endian_value >> 24) & 0xFF;
+    ip_address[1] = (big_endian_value >> 16) & 0xFF;
+    ip_address[2] = (big_endian_value >> 8) & 0xFF;
+    ip_address[3] = big_endian_value & 0xFF;
+
+    sprintf(ip_string, "%d.%d.%d.%d", ip_address[3], ip_address[2], ip_address[1], ip_address[0]);
+
+    return ip_string;
+}

--- a/5gc/upf_u/upf_u_helper.h
+++ b/5gc/upf_u/upf_u_helper.h
@@ -1,0 +1,42 @@
+/*
+# Copyright 2026 University of California, Riverside and National Yang Ming Chiao Tung University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+*/
+
+#ifndef UPF_U_HELPER_H
+#define UPF_U_HELPER_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <arpa/inet.h>
+
+const char *
+ipv4_to_buf(uint32_t be_addr, char buf[16]);
+
+void
+dump_gtpu(const uint8_t *start, size_t len, size_t gtp_off);
+
+const char*
+ip4(uint32_t host_ip);
+
+uint32_t
+charStr2MaskedIP(char *str, uint32_t *prefix_val);
+
+char *
+convertToIpAddressString(uint32_t big_endian_value);
+
+#endif


### PR DESCRIPTION
## Summary

This PR cleans up the UPF-U dataplane code structure and completes the transition from static L2 forwarding to ARP-based next-hop resolution.

The main changes are:
- split UPF-U utility, config, and ARP logic into separate modules
- remove the old static peer-MAC based L2 attachment path
- use configured access/core ports and peer IPs for UL/DL forwarding
- add ARP request/reply handling and neighbor-table based L2 resolution
- initialize ONVM dynamic field metadata before packet processing
- make the UPF-U log level configurable from `upf_u.yaml`

## Details

### Code organization
- moved helper routines into `upf_u_helper.{h,c}`
- moved config parsing and local L2 address initialization into `upf_u_config.{h,c}`
- moved ARP handling and neighbor resolution into `upf_u_arp.{h,c}`

### Dataplane behavior
- replaced the old `pkt->port ^ 1` assumption with explicit configured output ports
- replaced static `AttachL2Header()` forwarding with `attach_l2_or_arp()`
- use configured local/peer IPs for ARP-based next-hop resolution
- use configured access IP for uplink packet detection and GTP outer source IP

### ARP / neighbor handling
- added ARP packet interception before normal IPv4 processing
- added ARP request/reply handling inside UPF-U
- added neighbor table maintenance for next-hop MAC learning
- fixed ARP request broadcast destination handling
- unified ARP packet allocation with `MProc_pktmbuf_pool`

### Config / logging
- removed obsolete static peer MAC config
- added configurable `log_level` in `config/upf_u.yaml`

## Validation

Tested successfully with UERANSim:
- `ping` works
- `iperf3` works

These tests confirm that the updated UPF-U dataplane and ARP-based forwarding path are functioning correctly.