### PR TITLE
 fix: buffer leakage

### DIFF
--- a/5gc/upf_c/n4_dispatcher.c
+++ b/5gc/upf_c/n4_dispatcher.c
@@ -82,7 +82,7 @@ void UpfDispatcher(const Event *event) {
 
             UTLT_Assert(recvBufBlk, return, "recv buffer no data");
             bufBlk = BufblkAlloc(1, sizeof(PfcpMessage));
-            UTLT_Assert(bufBlk, return, "create buffer error");
+            UTLT_Assert(bufBlk, BufblkFree(recvBufBlk); return, "create buffer error");
             pfcpMessage = bufBlk->buf;
             UTLT_Assert(pfcpMessage, goto freeBuf, "pfcpMessage assigned error");
 
@@ -172,6 +172,7 @@ void UpfDispatcher(const Event *event) {
             freeBuf:
                 PfcpStructFree(pfcpMessage);
                 BufblkFree(bufBlk);
+                BufblkFree(recvBufBlk);
             break;
         }
         case UPF_EVENT_N4_T3_RESPONSE:

--- a/5gc/upf_c/n4_onvm_pfcp_path.c
+++ b/5gc/upf_c/n4_onvm_pfcp_path.c
@@ -161,13 +161,13 @@ int packet_handler(
     Event event;
     Status status;
     Bufblk *bufBlk = NULL;
-    bufBlk = BufblkAlloc(1, MAX_SDU_LEN);
+    uint32_t pfcpPayloadLen = pkt->pkt_len - outerHeader;
+    bufBlk = BufblkAlloc(1, pfcpPayloadLen);
     if (bufBlk == NULL) {
         return 0;
     }
-    bufBlk->buf = pfcpHeader;
-    bufBlk->size = pkt->pkt_len - outerHeader;
-    bufBlk->len = pkt->pkt_len - outerHeader;
+    memcpy(bufBlk->buf, pfcpHeader, pfcpPayloadLen);
+    bufBlk->len = pfcpPayloadLen;
 
     event.type = UPF_EVENT_N4_MESSAGE;
     event.arg0 = (uintptr_t)bufBlk;


### PR DESCRIPTION
@ShixiongQi, this pull request is for fixing memory leaks of `bufblkPool`, please help review it thanks!

In `n4_onvm_pfcp_path.c`:
* Code originally allocates a pool buffer and then overwrites `bufBlk->buf` with a packet pointer, which would leak the pool and caused `bufPool8192` exhaustion. Fixes make sure `bufBlk->buf` won't get overwrites.

In `n4_dispatcher.c`:
* Ensured `recvBufBlk` is correctly freed.

