### PR TITLE
upf-u: remove peer IP config and derive N3/N6 next-hop IPs dynamically

### DIFF
--- a/5gc/upf_u/config/upf_u.yaml
+++ b/5gc/upf_u/config/upf_u.yaml
@@ -7,8 +7,6 @@ configuration:
   dataplane:
     upf_n3_ip: "192.168.1.2"        # N3 interface IP address on the Core Network node
     upf_n6_ip: "192.168.1.3"        # N6 interface IP address on the Core Network node
-    an_peer_n3_ip: "192.168.1.1"    # N3 interface IP address on the UE/RAN node
-    dn_peer_n6_ip: "192.168.1.4"    # N6 interface IP address on the DN node
 
     ports:
       n3_port: 0                     # NIC port used for N3 interface

--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -1067,17 +1067,19 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
                 Encap(pkt, far, pdr->qer);
         }
 
-        // meta->destination = pkt->port ^ 1;
-        // AttachL2Header(pkt, true);
+        /* Get the gNB N3 IP address */
+        uint32_t gnb_n3_ip_be =
+            far->forwardingParameters.outerHeaderCreation.ipv4.s_addr;
+        UTLT_Trace("gNB N3 IP: %s\n", convertToIpAddressString(gnb_n3_ip_be));
 
         // Regardless of BUFF vs FORW, we need to attach L2 (or ARP) header
-        // before sending to access port.
-        if (attach_l2_or_arp(pkt, g_n3_port, g_n3_ip_be, g_an_peer_n3_ip_be,
+        // before sending to N3 port.
+        if (attach_l2_or_arp(pkt, g_n3_port, g_n3_ip_be, gnb_n3_ip_be,
                             nf_local_ctx->nf) < 0) {
             meta->action = ONVM_NF_ACTION_DROP;   /* or buffer */
             return 0;
         }
-        meta->destination = g_n3_port; // DL always goes to access port after FAR processing (may be modified by QoS policing below)
+        meta->destination = g_n3_port; // DL always goes to N3 port after FAR processing (may be modified by QoS policing below)
 
         if (far_action == UPDK_FAR_APPLY_ACTION_BUFF) {
             /* Buffer-only: prepare packet for later TX, enqueue, then DROP */
@@ -1168,9 +1170,28 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
     } else {
         /* ── UL: original HandlePacketWithFar path (unchanged) ── */
         int status = HandlePacketWithFar(pkt, far, pdr->qer, g_n6_port, meta);
-        // AttachL2Header(pkt, is_dl);
+
+        /* Get Inner IPv4 header */
+        struct rte_ipv4_hdr *inner_iph = rte_pktmbuf_mtod(pkt, struct rte_ipv4_hdr *);
+        if (inner_iph == NULL) {
+            UTLT_Warning("Inner packet is NULL, drop it\n");
+            meta->action = ONVM_NF_ACTION_DROP;
+            return 0;
+        }
+
+        if ((inner_iph->version_ihl >> 4) != 4) {
+            UTLT_Warning("Inner packet is not IPv4, drop it\n");
+            meta->action = ONVM_NF_ACTION_DROP;
+            return 0;
+        }
+
         if (meta->action == ONVM_NF_ACTION_OUT) {
-            if (attach_l2_or_arp(pkt, g_n6_port, g_n6_ip_be, g_dn_peer_n6_ip_be,
+            /* Get the DN server IP address */
+            uint32_t dn_server_ip_be = inner_iph->dst_addr;
+            UTLT_Trace("DN server IP: %s\n", convertToIpAddressString(dn_server_ip_be));
+
+            /* Attach L2 (or ARP) header for the N6-bound packet */
+            if (attach_l2_or_arp(pkt, g_n6_port, g_n6_ip_be, dn_server_ip_be,
                                 nf_local_ctx->nf) < 0) {
                 meta->action = ONVM_NF_ACTION_DROP;
                 return 0;

--- a/5gc/upf_u/upf_u_config.c
+++ b/5gc/upf_u/upf_u_config.c
@@ -34,8 +34,6 @@ uint16_t g_sgi_port    = 0;
 
 uint32_t g_n3_ip_be = 0;
 uint32_t g_n6_ip_be   = 0;
-uint32_t g_an_peer_n3_ip_be = 0;
-uint32_t g_dn_peer_n6_ip_be = 0;
 
 char g_log_level[16] = "warning";
 
@@ -169,48 +167,6 @@ do_parse(yaml_document_t *doc) {
 
         if (parse_ipv4_address(buf, &g_n6_ip_be) != 0) {
             fprintf(stderr, "[UPF-U][CONFIG] invalid upf_n6_ip\n");
-            return -1;
-        }
-    }
-
-    // an_peer_n3_ip
-    {
-        yaml_node_t *n = map_get(doc, dp, "an_peer_n3_ip");
-        if (!n || n->type != YAML_SCALAR_NODE) {
-            fprintf(stderr, "[UPF-U][CONFIG] missing an_peer_n3_ip\n");
-            return -1;
-        }
-        const unsigned char *p = n->data.scalar.value;
-        size_t len = n->data.scalar.length;
-
-        char buf[64];
-        if (len >= sizeof(buf)) len = sizeof(buf) - 1;
-        memcpy(buf, p, len);
-        buf[len] = '\0';
-
-        if (parse_ipv4_address(buf, &g_an_peer_n3_ip_be) != 0) {
-            fprintf(stderr, "[UPF-U][CONFIG] invalid an_peer_n3_ip\n");
-            return -1;
-        }
-    }
-
-    // dn_peer_n6_ip
-    {
-        yaml_node_t *n = map_get(doc, dp, "dn_peer_n6_ip");
-        if (!n || n->type != YAML_SCALAR_NODE) {
-            fprintf(stderr, "[UPF-U][CONFIG] missing dn_peer_n6_ip\n");
-            return -1;
-        }
-        const unsigned char *p = n->data.scalar.value;
-        size_t len = n->data.scalar.length;
-
-        char buf[64];
-        if (len >= sizeof(buf)) len = sizeof(buf) - 1;
-        memcpy(buf, p, len);
-        buf[len] = '\0';
-
-        if (parse_ipv4_address(buf, &g_dn_peer_n6_ip_be) != 0) {
-            fprintf(stderr, "[UPF-U][CONFIG] invalid dn_peer_n6_ip\n");
             return -1;
         }
     }

--- a/5gc/upf_u/upf_u_config.h
+++ b/5gc/upf_u/upf_u_config.h
@@ -25,9 +25,6 @@
 extern uint32_t g_n3_ip_be;     // UPF local IP on the access-facing port
 extern uint32_t g_n6_ip_be;     // UPF local IP on the core/SGi-facing port
 
-extern uint32_t g_an_peer_n3_ip_be;  // Next-hop IP of the AN/gNB peer
-extern uint32_t g_dn_peer_n6_ip_be;  // Next-hop IP of the DN/upstream router peer
-
 extern uint16_t  g_n3_port;      // UPF-U DPDK port connected to the access side (AN/gNB)
 extern uint16_t  g_n6_port;      // UPF-U DPDK port connected to the core side (SGi)
 extern uint16_t  g_sgi_port;     // UPF-U DPDK port connected to the SGi side


### PR DESCRIPTION
**PR description**

This PR removes the static peer IP configuration for UPF-U and derives the N3/N6 next-hop IPs directly from packet context at runtime.

### What changed

* Removed `an_peer_n3_ip` and `dn_peer_n6_ip` from `upf_u.yaml`
* Removed the corresponding global config variables and YAML parsing logic
* For downlink N3 forwarding, derive the gNB N3 IP from:

  * `far->forwardingParameters.outerHeaderCreation.ipv4.s_addr`
* For uplink N6 forwarding, derive the DN server IP from:

  * `inner_iph->dst_addr`
* Updated the UL path to read the inner IPv4 header from the current mbuf data pointer
* Added clearer local variable names such as:

  * `gnb_n3_ip_be`
  * `dn_server_ip_be`

### Why

Previously, UPF-U depended on statically configured peer IPs for N3 and N6 forwarding. That made the forwarding path less flexible and less clear, especially when the correct next hop was already available in the packet or FAR context.

This change makes the behavior more robust and easier to understand by:

* avoiding redundant peer IP configuration
* using the actual packet/FAR context as the source of truth
* making the forwarding logic easier to read and maintain

### Notes

* Downlink packets now use the FAR-provided outer header creation info as the source of the gNB N3 next hop.
* Uplink packets now use the inner IPv4 destination address as the DN-side next hop.
* The UL path also fixes inner IPv4 parsing by treating the current mbuf data pointer as the start of the inner IP packet, which matches the post-decap packet layout. 