### PR TITLE
Add non-blocking UPF-U token shaper

### DIFF
--- a/5gc/upf_c/n4_onvm_pfcp_build.h
+++ b/5gc/upf_c/n4_onvm_pfcp_build.h
@@ -47,17 +47,6 @@ Status UpfN4BuildHeartbeatResponse (
         Bufblk **bufBlkPtr, uint8_t type);
 
 
-static inline int UpfSendEvt1(uint16_t dest_sid, uint32_t type, uintptr_t a0) {
-    Event *e = (Event *)rte_calloc("upf_evt", 1, sizeof(*e), 0);
-    if (!e) return -1;
-    e->type = (uintptr_t)type;
-    e->argc = 1;
-    e->arg0 = a0;
-    int rc = onvm_nflib_send_msg_to_nf(dest_sid, e);
-    if (rc < 0) rte_free(e);
-    return rc;
-}
-
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -161,18 +161,6 @@ static uint64_t g_shaper_drop_flow_queue_full;
 static uint64_t g_shaper_drop_ue_queue_full;
 static uint64_t g_shaper_drop_mempool_empty;
 
-static inline int
-UpfSendEvt1(uint16_t dest_sid, uint32_t type, uintptr_t a0) {
-    Event *e = (Event *)rte_calloc("upf_evt", 1, sizeof(*e), 0);
-    if (!e) return -1;
-    e->type = (uintptr_t)type;
-    e->argc = 1;
-    e->arg0 = a0;
-    int rc = onvm_nflib_send_msg_to_nf(dest_sid, e);
-    if (rc < 0) rte_free(e);
-    return rc;
-}
-
 typedef struct {
     void    *ptr;          // current active snapshot (cls_handle_t*)
     uint32_t ver;          // last applied version

--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -955,6 +955,11 @@ build_dl_shaper_flow_key(struct rte_mbuf *pkt, const UPDK_PDR *pdr,
     return true;
 }
 
+static inline uint64_t
+saturating_add_u64(uint64_t lhs, uint64_t rhs) {
+    return UINT64_MAX - lhs < rhs ? UINT64_MAX : lhs + rhs;
+}
+
 UPDK_PDR *
 GetPdrByUeIpAddress(struct rte_mbuf *pkt, uint32_t ue_ip)
 {
@@ -1071,6 +1076,7 @@ GetQerByUEIpAddressFromPdr(uint32_t ue_ip, const UPDK_PDR *pdr, const char *ip_s
     uint64_t ambr64 = 0;
     uint64_t gbr64  = 0;
     uint64_t mbr64  = 0;
+    bool has_gbr_qer = false;
 
     int n = (int)pdr->qer_count;
     if (n > 2) n = 2; /* safety; struct currently supports 2 */
@@ -1082,10 +1088,10 @@ GetQerByUEIpAddressFromPdr(uint32_t ue_ip, const UPDK_PDR *pdr, const char *ip_s
         if (q->flags.maximumBitrate && q->maximumBitrate.dl > ambr64)
             ambr64 = q->maximumBitrate.dl;
 
-        /* old behavior: only set gbr/mbr when both flags are present */
         if (q->flags.guaranteedBitrate && q->flags.maximumBitrate) {
-            gbr64 = q->guaranteedBitrate.dl;
-            mbr64 = q->maximumBitrate.dl;
+            has_gbr_qer = true;
+            gbr64 = saturating_add_u64(gbr64, q->guaranteedBitrate.dl);
+            mbr64 = saturating_add_u64(mbr64, q->maximumBitrate.dl);
         }
     }
 
@@ -1100,6 +1106,8 @@ GetQerByUEIpAddressFromPdr(uint32_t ue_ip, const UPDK_PDR *pdr, const char *ip_s
     uint32_t gbr  = (gbr64  > UINT32_MAX) ? UINT32_MAX : (uint32_t)gbr64;
     uint32_t mbr  = (mbr64  > UINT32_MAX) ? UINT32_MAX : (uint32_t)mbr64;
 
+    if (!has_gbr_qer)
+        mbr = 0;
     if (mbr && gbr > mbr) gbr = mbr;
 
     UTLT_Warning("Add UE IP: %s, AMBR: %u GBR: %u, MBR: %u",

--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -1456,12 +1456,11 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
             int color_result = 0;
             bool isQos = false;
             uint64_t curr_time = rte_get_tsc_cycles();
-            struct rte_meter_trtcm_profile *trtcm_profile = NULL;
 
             if (pdr->has_fd) {
                 isQos = true;
-                trtcm_profile = &app_flow_trtcm_profile;
                 int ft_idx = ftSearch(pdr->meter_key);
+                struct rte_meter_trtcm_profile *trtcm_profile;
                 if (unlikely(ft_idx < 0 || ft_idx >= (int)APP_FLOWS_MAX)) {
                     UTLT_Warning("DL QoS: no trTCM flow for meter_key=%u (ft_idx=%d) pdr=%u seid=%lu; dropping",
                                  pdr->meter_key, ft_idx, pdr->pdrId, seid);
@@ -1469,8 +1468,21 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
                     meta->action = ONVM_NF_ACTION_DROP;
                     goto dl_nocp;
                 }
+                trtcm_profile = trtcmProfileForFlow(ft_idx);
+                if (unlikely(trtcm_profile == NULL)) {
+                    UTLT_Warning("DL QoS: no trTCM profile for meter_key=%u ft_idx=%d pdr=%u seid=%lu; dropping",
+                                 pdr->meter_key, ft_idx, pdr->pdrId, seid);
+                    meta->flags = RTE_COLOR_RED;
+                    meta->action = ONVM_NF_ACTION_DROP;
+                    goto dl_nocp;
+                }
                 color_result = trtcmColorHandle(cal_pktlen, curr_time,
                                                 ft_idx, trtcm_profile);
+                if (unlikely(color_result < 0)) {
+                    meta->flags = RTE_COLOR_RED;
+                    meta->action = ONVM_NF_ACTION_DROP;
+                    goto dl_nocp;
+                }
                 // set the meta action to out for now, and trtcmPolicer will update it to drop if color is red
                 meta->action = ONVM_NF_ACTION_OUT;
                 if (trtcmPolicer(meta, color_result) > 0)
@@ -1563,8 +1575,22 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
                     }
 
                     uint64_t curr_time = rte_get_tsc_cycles();
+                    struct rte_meter_trtcm_profile *trtcm_profile =
+                        trtcmProfileForFlow(ft_idx);
+                    if (unlikely(trtcm_profile == NULL)) {
+                        UTLT_Warning("UL QoS: no trTCM profile for meter_key=%u ft_idx=%d pdr=%u seid=%lu; dropping",
+                                    pdr->meter_key, ft_idx, pdr->pdrId, seid);
+                        meta->flags = RTE_COLOR_RED;
+                        meta->action = ONVM_NF_ACTION_DROP;
+                        return 0;
+                    }
                     int color_result = trtcmColorHandle(pkt->pkt_len, curr_time,
-                                                        ft_idx, &app_flow_trtcm_profile);
+                                                        ft_idx, trtcm_profile);
+                    if (unlikely(color_result < 0)) {
+                        meta->flags = RTE_COLOR_RED;
+                        meta->action = ONVM_NF_ACTION_DROP;
+                        return 0;
+                    }
                     if (trtcmPolicer(meta, color_result) > 0)
                         UTLT_Error("UL trTCM Policer error");
 

--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -73,7 +73,10 @@
 /* Used for non-blocking UE token-bucket shaping */
 #define SHAPER_SCAN_BUDGET       32
 #define SHAPER_DRAIN_BUDGET      128
+#define SHAPER_INLINE_DRAIN_BUDGET 32
 #define SHAPER_CLASS_BURST        16
+#define SHAPER_MAX_QUEUE_DELAY_MS 100
+#define SHAPER_MIN_QUEUE_PKTS     4
 #define SHAPER_MAX_FLOWS_PER_UE  64
 #define SHAPER_MAX_PKTS_PER_FLOW 512
 #define SHAPER_MAX_PKTS_PER_UE   2048
@@ -501,6 +504,52 @@ shaper_count_overflow(enum shaper_pkt_color color) {
         __atomic_fetch_add(&g_shaper_drop_nqos_overflow, 1, __ATOMIC_RELAXED);
 }
 
+static void
+shaper_drop_head_locked(struct ue_shaper *ue, struct shaper_flow *flow) {
+    struct shaper_entry *entry;
+
+    if (ue == NULL || flow == NULL || flow->head == NULL)
+        return;
+
+    entry = flow->head;
+    flow->head = entry->next;
+    if (flow->head == NULL)
+        flow->tail = NULL;
+    flow->queued_pkts--;
+    flow->queued_bytes -= entry->pkt_len;
+    ue->queued_pkts--;
+
+    rte_pktmbuf_free(entry->pkt);
+    shaper_count_overflow(entry->color);
+    shaper_free_entry(entry);
+    __atomic_fetch_add(&g_shaper_drop_flow_queue_full, 1,
+                       __ATOMIC_RELAXED);
+}
+
+static void
+shaper_trim_flow_for_enqueue_locked(struct ue_shaper *ue,
+                                    struct shaper_flow *flow,
+                                    uint32_t pkt_len,
+                                    uint64_t queue_limit_bytes) {
+    bool was_active;
+
+    if (ue == NULL || flow == NULL || flow->queued_pkts == 0)
+        return;
+
+    was_active = flow->active_list != SHAPER_ACTIVE_NONE;
+    if (was_active)
+        shaper_deactivate_flow(ue, flow);
+
+    while (flow->head != NULL &&
+           (flow->queued_pkts >= SHAPER_MAX_PKTS_PER_FLOW ||
+            (uint64_t)flow->queued_bytes + pkt_len > queue_limit_bytes)) {
+        shaper_drop_head_locked(ue, flow);
+    }
+
+    if (flow->head != NULL)
+        shaper_activate_flow(ue, flow);
+}
+
 static inline bool
 shaper_class_has_backlog_locked(const struct ue_shaper *ue,
                                 enum ue_bucket_class bucket_class) {
@@ -538,17 +587,33 @@ shape_or_enqueue_packet(int ue_idx, const struct shaper_flow_key *key,
     struct shaper_entry *entry;
     enum ue_bucket_class bucket_class =
         shaper_bucket_for_packet(is_qos, color);
+    uint64_t min_queue_bytes;
+    uint64_t queue_limit_bytes;
+
+    if (unlikely(pkt == NULL || key == NULL || g_shaper_entry_pool == NULL)) {
+        meta->action = ONVM_NF_ACTION_DROP;
+        shaper_count_overflow(color);
+        return SHAPER_DROP;
+    }
+    if (pkt_len == 0)
+        pkt_len = rte_pktmbuf_pkt_len(pkt);
+    if (pkt_len == 0) {
+        meta->action = ONVM_NF_ACTION_DROP;
+        __atomic_fetch_add(&g_shaper_drop_invalid, 1, __ATOMIC_RELAXED);
+        return SHAPER_DROP;
+    }
+    min_queue_bytes = (uint64_t)pkt_len * SHAPER_MIN_QUEUE_PKTS;
 
     if (!ueBucketCanFitPacket(ue_idx, bucket_class, pkt_len)) {
         meta->action = ONVM_NF_ACTION_DROP;
         __atomic_fetch_add(&g_shaper_drop_invalid, 1, __ATOMIC_RELAXED);
         return SHAPER_DROP;
     }
-    if (unlikely(pkt == NULL || key == NULL || g_shaper_entry_pool == NULL)) {
-        meta->action = ONVM_NF_ACTION_DROP;
-        shaper_count_overflow(color);
-        return SHAPER_DROP;
-    }
+
+    queue_limit_bytes =
+        ueShaperQueueLimitBytes(ue_idx, is_qos,
+                                SHAPER_MAX_QUEUE_DELAY_MS,
+                                min_queue_bytes);
 
     ue = &g_ue_shaper[ue_idx];
     rte_spinlock_lock(&ue->lock);
@@ -571,6 +636,8 @@ shape_or_enqueue_packet(int ue_idx, const struct shaper_flow_key *key,
         shaper_count_overflow(color);
         return SHAPER_DROP;
     }
+    shaper_trim_flow_for_enqueue_locked(ue, flow, pkt_len,
+                                        queue_limit_bytes);
     if (flow->queued_pkts >= SHAPER_MAX_PKTS_PER_FLOW) {
         rte_spinlock_unlock(&ue->lock);
         meta->action = ONVM_NF_ACTION_DROP;
@@ -580,6 +647,8 @@ shape_or_enqueue_packet(int ue_idx, const struct shaper_flow_key *key,
         return SHAPER_DROP;
     }
     if (ue->queued_pkts >= SHAPER_MAX_PKTS_PER_UE) {
+        if (flow->queued_pkts == 0)
+            shaper_release_empty_flow(ue, flow);
         rte_spinlock_unlock(&ue->lock);
         meta->action = ONVM_NF_ACTION_DROP;
         __atomic_fetch_add(&g_shaper_drop_ue_queue_full, 1,
@@ -588,6 +657,8 @@ shape_or_enqueue_packet(int ue_idx, const struct shaper_flow_key *key,
         return SHAPER_DROP;
     }
     if (rte_mempool_get(g_shaper_entry_pool, (void **)&entry) != 0) {
+        if (flow->queued_pkts == 0)
+            shaper_release_empty_flow(ue, flow);
         rte_spinlock_unlock(&ue->lock);
         meta->action = ONVM_NF_ACTION_DROP;
         __atomic_fetch_add(&g_shaper_drop_mempool_empty, 1,
@@ -838,10 +909,9 @@ drain_ue_shaper(int ue_idx, struct onvm_nf *nf, uint32_t budget) {
 }
 
 static uint32_t
-drain_shaper_queues(struct onvm_nf *nf) {
+drain_shaper_queues_budget(struct onvm_nf *nf, uint32_t budget) {
     uint64_t tried_ue_bitmap[SHAPER_UE_BITMAP_WORDS] = {0};
     uint32_t total = 0;
-    uint32_t budget = SHAPER_DRAIN_BUDGET;
 
     for (uint32_t visited = 0; visited < SHAPER_SCAN_BUDGET && budget > 0; visited++) {
         int ue_idx = shaper_next_active_ue(tried_ue_bitmap);
@@ -858,6 +928,11 @@ drain_shaper_queues(struct onvm_nf *nf) {
     }
 
     return total;
+}
+
+static uint32_t
+drain_shaper_queues(struct onvm_nf *nf) {
+    return drain_shaper_queues_budget(nf, SHAPER_DRAIN_BUDGET);
 }
 
 static void
@@ -1373,6 +1448,9 @@ drain_session_batch(int sess_idx, uint32_t max_pkts, struct onvm_nf *nf) {
 
 static int
 packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_local_ctx *nf_local_ctx) {
+    if (nf_local_ctx != NULL && nf_local_ctx->nf != NULL)
+        drain_shaper_queues_budget(nf_local_ctx->nf,
+                                   SHAPER_INLINE_DRAIN_BUDGET);
     if (pkt == NULL || meta == NULL) {
         return 0;
     }

--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -19,6 +19,7 @@
 #include <errno.h>
 #include <getopt.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -35,6 +36,12 @@
 #include <rte_ether.h>
 #include <rte_mbuf.h>
 #include <rte_meter.h>
+#include <rte_malloc.h>
+#include <rte_mempool.h>
+#include <rte_ring.h>
+#include <rte_ring_peek.h>
+#include <rte_spinlock.h>
+#include <rte_tcp.h>
 
 #include "gtp.h"
 #include "upf_context.h"
@@ -63,8 +70,96 @@
 #define INLINE_DRAIN_BATCH       8    /* pkts drained per INLINE (FORW)  */
 #define DRAIN_CHUNK             64    /* max pkts dequeued per drain call */
 
+/* Used for non-blocking UE token-bucket shaping */
+#define SHAPER_SCAN_BUDGET       32
+#define SHAPER_DRAIN_BUDGET      64
+#define SHAPER_CLASS_BURST        8
+#define SHAPER_MAX_FLOWS_PER_UE  64
+#define SHAPER_MAX_PKTS_PER_FLOW 256
+#define SHAPER_MAX_PKTS_PER_UE   1024
+#define SHAPER_ENTRY_POOL_CACHE  256
+#define SHAPER_UE_BITMAP_WORDS   ((MAX_UE + 63) / 64)
+
 uint64_t seid = 0;
 uint16_t pdrId = 0;
+
+enum shaper_decision {
+    SHAPER_PASS = 0,
+    SHAPER_QUEUED,
+    SHAPER_DROP
+};
+
+enum shaper_pkt_color {
+    SHAPER_COLOR_NQOS = 0,
+    SHAPER_COLOR_GREEN,
+    SHAPER_COLOR_YELLOW
+};
+
+enum shaper_active_list_id {
+    SHAPER_ACTIVE_NONE = 0,
+    SHAPER_ACTIVE_GREEN,
+    SHAPER_ACTIVE_YELLOW,
+    SHAPER_ACTIVE_NQOS,
+    SHAPER_ACTIVE_COUNT
+};
+
+struct shaper_flow_key {
+    uint32_t ue_ip;
+    uint32_t src_ip;
+    uint32_t dst_ip;
+    uint16_t src_port;
+    uint16_t dst_port;
+    uint8_t proto;
+    uint8_t qfi;
+    uint8_t is_qos;
+};
+
+struct shaper_entry {
+    struct rte_mbuf *pkt;
+    uint32_t pkt_len;
+    uint16_t destination;
+    enum shaper_pkt_color color;
+    struct shaper_entry *next;
+};
+
+struct shaper_flow {
+    bool in_use;
+    struct shaper_flow_key key;
+    struct shaper_entry *head;
+    struct shaper_entry *tail;
+    uint32_t queued_pkts;
+    uint32_t queued_bytes;
+    enum shaper_active_list_id active_list;
+    uint64_t last_active_tsc;
+    TAILQ_ENTRY(shaper_flow) active_node;
+};
+
+TAILQ_HEAD(shaper_flow_head, shaper_flow);
+
+struct ue_shaper {
+    rte_spinlock_t lock;
+    struct shaper_flow flows[SHAPER_MAX_FLOWS_PER_UE];
+    struct shaper_flow_head active[SHAPER_ACTIVE_COUNT];
+    uint32_t active_count[SHAPER_ACTIVE_COUNT];
+    uint32_t queued_pkts;
+    uint8_t next_excess_is_yellow;
+};
+
+static struct ue_shaper g_ue_shaper[MAX_UE];
+static struct rte_mempool *g_shaper_entry_pool;
+static uint64_t g_shaper_active_ue_bitmap[SHAPER_UE_BITMAP_WORDS];
+static uint32_t g_shaper_active_ue_cursor;
+static uint64_t g_shaper_queued;
+static uint64_t g_shaper_drained;
+static uint64_t g_shaper_drop_invalid;
+static uint64_t g_shaper_drop_red;
+static uint64_t g_shaper_drop_green_overflow;
+static uint64_t g_shaper_drop_yellow_overflow;
+static uint64_t g_shaper_drop_nqos_overflow;
+static uint64_t g_shaper_drop_flow_table_full;
+static uint64_t g_shaper_drop_flow_queue_full;
+static uint64_t g_shaper_drop_ue_queue_full;
+static uint64_t g_shaper_drop_mempool_empty;
 
 static inline int
 UpfSendEvt1(uint16_t dest_sid, uint32_t type, uintptr_t a0) {
@@ -177,6 +272,687 @@ UpfClassifyGetPdrPtr(const ps_packet_t *key) {
     int hit = cls_classify_packet((cls_handle_t *)snap, key, &precedence, &descriptor);
     if (hit != 1 || descriptor == 0) return NULL;
     return (const UPDK_PDR *)descriptor;
+}
+
+static int
+shaper_init_entry_pool(struct onvm_nf *nf) {
+    char name[64];
+    uint64_t entry_count64 = (uint64_t)MAX_UE * SHAPER_MAX_PKTS_PER_UE;
+    unsigned int entry_count;
+    uint16_t instance_id = nf ? nf->instance_id : 0;
+
+    if (g_shaper_entry_pool != NULL)
+        return 0;
+
+    if (entry_count64 == 0 || entry_count64 > UINT_MAX) {
+        UTLT_Error("Invalid shaper entry pool size: %" PRIu64,
+                   entry_count64);
+        return -1;
+    }
+    entry_count = (unsigned int)entry_count64;
+
+    snprintf(name, sizeof(name), "us_entry_%03u", instance_id);
+    g_shaper_entry_pool = rte_mempool_lookup(name);
+    if (g_shaper_entry_pool != NULL)
+        return 0;
+
+    g_shaper_entry_pool = rte_mempool_create(name, entry_count,
+                                             sizeof(struct shaper_entry),
+                                             SHAPER_ENTRY_POOL_CACHE, 0,
+                                             NULL, NULL, NULL, NULL,
+                                             SOCKET_ID_ANY, 0);
+    if (g_shaper_entry_pool == NULL)
+        g_shaper_entry_pool = rte_mempool_lookup(name);
+    if (g_shaper_entry_pool == NULL) {
+        UTLT_Error("Failed to create shaper entry pool %s", name);
+        return -1;
+    }
+    return 0;
+}
+
+static void
+shaper_init_state(void) {
+    for (uint32_t word_idx = 0; word_idx < SHAPER_UE_BITMAP_WORDS; word_idx++)
+        __atomic_store_n(&g_shaper_active_ue_bitmap[word_idx], 0,
+                         __ATOMIC_RELEASE);
+    g_shaper_active_ue_cursor = 0;
+
+    for (int ue_idx = 0; ue_idx < MAX_UE; ue_idx++) {
+        rte_spinlock_init(&g_ue_shaper[ue_idx].lock);
+        for (int list_id = 0; list_id < SHAPER_ACTIVE_COUNT; list_id++)
+            TAILQ_INIT(&g_ue_shaper[ue_idx].active[list_id]);
+        g_ue_shaper[ue_idx].next_excess_is_yellow = 1;
+    }
+}
+
+static inline void
+shaper_free_entry(struct shaper_entry *entry) {
+    if (entry != NULL && g_shaper_entry_pool != NULL)
+        rte_mempool_put(g_shaper_entry_pool, entry);
+}
+
+static inline uint64_t
+shaper_ue_bitmap_valid_mask(uint32_t word_idx) {
+    uint32_t used_bits;
+
+    if (word_idx + 1 < SHAPER_UE_BITMAP_WORDS)
+        return UINT64_MAX;
+
+    used_bits = MAX_UE & 63;
+    return used_bits == 0 ? UINT64_MAX : ((1ULL << used_bits) - 1);
+}
+
+static inline void
+shaper_mark_ue_active(int ue_idx) {
+    uint32_t word_idx = (uint32_t)ue_idx / 64;
+    uint64_t bit = 1ULL << ((uint32_t)ue_idx & 63);
+
+    __atomic_fetch_or(&g_shaper_active_ue_bitmap[word_idx], bit,
+                      __ATOMIC_RELEASE);
+}
+
+static inline void
+shaper_clear_ue_active(int ue_idx) {
+    uint32_t word_idx = (uint32_t)ue_idx / 64;
+    uint64_t bit = 1ULL << ((uint32_t)ue_idx & 63);
+
+    __atomic_fetch_and(&g_shaper_active_ue_bitmap[word_idx], ~bit,
+                       __ATOMIC_RELEASE);
+}
+
+static int
+shaper_next_active_ue(const uint64_t *skip_bitmap) {
+    uint32_t start = g_shaper_active_ue_cursor % MAX_UE;
+    uint32_t start_word = start / 64;
+    uint32_t start_bit = start & 63;
+
+    for (uint32_t pass = 0; pass < 2; pass++) {
+        uint32_t first_word = pass == 0 ? start_word : 0;
+        uint32_t last_word = pass == 0 ? SHAPER_UE_BITMAP_WORDS
+                                       : start_word + 1;
+
+        for (uint32_t word_idx = first_word; word_idx < last_word; word_idx++) {
+            uint64_t word = __atomic_load_n(&g_shaper_active_ue_bitmap[word_idx],
+                                            __ATOMIC_ACQUIRE);
+            word &= shaper_ue_bitmap_valid_mask(word_idx);
+            if (skip_bitmap != NULL)
+                word &= ~skip_bitmap[word_idx];
+            if (pass == 0 && word_idx == start_word) {
+                if (start_bit > 0)
+                    word &= UINT64_MAX << start_bit;
+            } else if (pass == 1 && word_idx == start_word) {
+                if (start_bit == 0)
+                    word = 0;
+                else
+                    word &= (1ULL << start_bit) - 1;
+            }
+            if (word == 0)
+                continue;
+
+            uint32_t bit = (uint32_t)__builtin_ctzll(word);
+            uint32_t ue_idx = word_idx * 64 + bit;
+            g_shaper_active_ue_cursor = (ue_idx + 1) % MAX_UE;
+            return (int)ue_idx;
+        }
+    }
+
+    return -1;
+}
+
+static inline bool
+shaper_flow_key_equal(const struct shaper_flow_key *a,
+                      const struct shaper_flow_key *b) {
+    return a->ue_ip == b->ue_ip &&
+           a->src_ip == b->src_ip &&
+           a->dst_ip == b->dst_ip &&
+           a->src_port == b->src_port &&
+           a->dst_port == b->dst_port &&
+           a->proto == b->proto &&
+           a->qfi == b->qfi &&
+           a->is_qos == b->is_qos;
+}
+
+static inline uint32_t
+shaper_flow_hash(const struct shaper_flow_key *key) {
+    uint32_t h = 2166136261u;
+
+    h = (h ^ key->ue_ip) * 16777619u;
+    h = (h ^ key->src_ip) * 16777619u;
+    h = (h ^ key->dst_ip) * 16777619u;
+    h = (h ^ (((uint32_t)key->src_port << 16) | key->dst_port)) * 16777619u;
+    h = (h ^ (((uint32_t)key->proto << 16) |
+              ((uint32_t)key->qfi << 8) | key->is_qos)) * 16777619u;
+    return h;
+}
+
+static struct shaper_flow *
+shaper_lookup_flow(struct ue_shaper *ue, const struct shaper_flow_key *key,
+                   bool create) {
+    uint32_t start = shaper_flow_hash(key) % SHAPER_MAX_FLOWS_PER_UE;
+    int free_idx = -1;
+
+    for (uint32_t probe = 0; probe < SHAPER_MAX_FLOWS_PER_UE; probe++) {
+        uint32_t idx = (start + probe) % SHAPER_MAX_FLOWS_PER_UE;
+        struct shaper_flow *flow = &ue->flows[idx];
+
+        if (flow->in_use) {
+            if (shaper_flow_key_equal(&flow->key, key))
+                return flow;
+            continue;
+        }
+        if (free_idx < 0)
+            free_idx = (int)idx;
+    }
+
+    if (!create || free_idx < 0)
+        return NULL;
+
+    struct shaper_flow *flow = &ue->flows[free_idx];
+    memset(flow, 0, sizeof(*flow));
+    flow->in_use = true;
+    flow->key = *key;
+    flow->active_list = SHAPER_ACTIVE_NONE;
+    return flow;
+}
+
+static inline enum shaper_active_list_id
+shaper_active_list_for_head(const struct shaper_flow *flow) {
+    if (flow == NULL || flow->head == NULL)
+        return SHAPER_ACTIVE_NONE;
+    if (!flow->key.is_qos)
+        return SHAPER_ACTIVE_NQOS;
+    switch (flow->head->color) {
+    case SHAPER_COLOR_GREEN:
+        return SHAPER_ACTIVE_GREEN;
+    case SHAPER_COLOR_YELLOW:
+        return SHAPER_ACTIVE_YELLOW;
+    default:
+        return SHAPER_ACTIVE_NONE;
+    }
+}
+
+static inline void
+shaper_activate_flow(struct ue_shaper *ue, struct shaper_flow *flow) {
+    enum shaper_active_list_id list_id = shaper_active_list_for_head(flow);
+
+    if (list_id == SHAPER_ACTIVE_NONE)
+        return;
+
+    if (flow->active_list != SHAPER_ACTIVE_NONE) {
+        TAILQ_REMOVE(&ue->active[flow->active_list], flow, active_node);
+        ue->active_count[flow->active_list]--;
+    }
+    TAILQ_INSERT_TAIL(&ue->active[list_id], flow, active_node);
+    ue->active_count[list_id]++;
+    flow->active_list = list_id;
+    flow->last_active_tsc = rte_get_tsc_cycles();
+}
+
+static inline void
+shaper_deactivate_flow(struct ue_shaper *ue, struct shaper_flow *flow) {
+    if (flow->active_list == SHAPER_ACTIVE_NONE)
+        return;
+    TAILQ_REMOVE(&ue->active[flow->active_list], flow, active_node);
+    ue->active_count[flow->active_list]--;
+    flow->active_list = SHAPER_ACTIVE_NONE;
+}
+
+static inline void
+shaper_release_empty_flow(struct ue_shaper *ue, struct shaper_flow *flow) {
+    shaper_deactivate_flow(ue, flow);
+    memset(flow, 0, sizeof(*flow));
+}
+
+static inline void
+shaper_count_overflow(enum shaper_pkt_color color) {
+    if (color == SHAPER_COLOR_GREEN)
+        __atomic_fetch_add(&g_shaper_drop_green_overflow, 1, __ATOMIC_RELAXED);
+    else if (color == SHAPER_COLOR_YELLOW)
+        __atomic_fetch_add(&g_shaper_drop_yellow_overflow, 1, __ATOMIC_RELAXED);
+    else
+        __atomic_fetch_add(&g_shaper_drop_nqos_overflow, 1, __ATOMIC_RELAXED);
+}
+
+static inline bool
+shaper_class_has_backlog_locked(const struct ue_shaper *ue,
+                                enum ue_bucket_class bucket_class) {
+    switch (bucket_class) {
+    case UE_BUCKET_GREEN:
+        return ue->active_count[SHAPER_ACTIVE_GREEN] > 0;
+    case UE_BUCKET_YELLOW:
+    case UE_BUCKET_NQOS:
+        return ue->active_count[SHAPER_ACTIVE_GREEN] > 0 ||
+               ue->active_count[SHAPER_ACTIVE_YELLOW] > 0 ||
+               ue->active_count[SHAPER_ACTIVE_NQOS] > 0;
+    default:
+        return false;
+    }
+}
+
+static inline enum ue_bucket_class
+shaper_bucket_for_packet(bool is_qos, enum shaper_pkt_color color) {
+    if (!is_qos)
+        return UE_BUCKET_NQOS;
+    if (color == SHAPER_COLOR_GREEN)
+        return UE_BUCKET_GREEN;
+    if (color == SHAPER_COLOR_YELLOW)
+        return UE_BUCKET_YELLOW;
+    return UE_BUCKET_NQOS;
+}
+
+static enum shaper_decision
+shape_or_enqueue_packet(int ue_idx, const struct shaper_flow_key *key,
+                        bool is_qos, enum shaper_pkt_color color,
+                        struct rte_mbuf *pkt, uint32_t pkt_len,
+                        struct onvm_pkt_meta *meta) {
+    struct ue_shaper *ue;
+    struct shaper_flow *flow;
+    struct shaper_entry *entry;
+    enum ue_bucket_class bucket_class =
+        shaper_bucket_for_packet(is_qos, color);
+
+    if (!ueBucketCanFitPacket(ue_idx, bucket_class, pkt_len)) {
+        meta->action = ONVM_NF_ACTION_DROP;
+        __atomic_fetch_add(&g_shaper_drop_invalid, 1, __ATOMIC_RELAXED);
+        return SHAPER_DROP;
+    }
+    if (unlikely(pkt == NULL || key == NULL || g_shaper_entry_pool == NULL)) {
+        meta->action = ONVM_NF_ACTION_DROP;
+        shaper_count_overflow(color);
+        return SHAPER_DROP;
+    }
+
+    ue = &g_ue_shaper[ue_idx];
+    rte_spinlock_lock(&ue->lock);
+
+    flow = shaper_lookup_flow(ue, key, false);
+    if (flow == NULL &&
+        !shaper_class_has_backlog_locked(ue, bucket_class) &&
+        consumeUeBucketTokens(ue_idx, bucket_class, pkt_len)) {
+        rte_spinlock_unlock(&ue->lock);
+        return SHAPER_PASS;
+    }
+
+    if (flow == NULL)
+        flow = shaper_lookup_flow(ue, key, true);
+    if (flow == NULL) {
+        rte_spinlock_unlock(&ue->lock);
+        meta->action = ONVM_NF_ACTION_DROP;
+        __atomic_fetch_add(&g_shaper_drop_flow_table_full, 1,
+                           __ATOMIC_RELAXED);
+        shaper_count_overflow(color);
+        return SHAPER_DROP;
+    }
+    if (flow->queued_pkts >= SHAPER_MAX_PKTS_PER_FLOW) {
+        rte_spinlock_unlock(&ue->lock);
+        meta->action = ONVM_NF_ACTION_DROP;
+        __atomic_fetch_add(&g_shaper_drop_flow_queue_full, 1,
+                           __ATOMIC_RELAXED);
+        shaper_count_overflow(color);
+        return SHAPER_DROP;
+    }
+    if (ue->queued_pkts >= SHAPER_MAX_PKTS_PER_UE) {
+        rte_spinlock_unlock(&ue->lock);
+        meta->action = ONVM_NF_ACTION_DROP;
+        __atomic_fetch_add(&g_shaper_drop_ue_queue_full, 1,
+                           __ATOMIC_RELAXED);
+        shaper_count_overflow(color);
+        return SHAPER_DROP;
+    }
+    if (rte_mempool_get(g_shaper_entry_pool, (void **)&entry) != 0) {
+        rte_spinlock_unlock(&ue->lock);
+        meta->action = ONVM_NF_ACTION_DROP;
+        __atomic_fetch_add(&g_shaper_drop_mempool_empty, 1,
+                           __ATOMIC_RELAXED);
+        shaper_count_overflow(color);
+        return SHAPER_DROP;
+    }
+
+    entry->pkt = pkt;
+    entry->pkt_len = pkt_len;
+    entry->destination = meta->destination;
+    entry->color = color;
+    entry->next = NULL;
+
+    rte_mbuf_refcnt_update(pkt, 1);
+    if (flow->tail != NULL)
+        flow->tail->next = entry;
+    else
+        flow->head = entry;
+    flow->tail = entry;
+    flow->queued_pkts++;
+    flow->queued_bytes += pkt_len;
+    ue->queued_pkts++;
+
+    if (flow->queued_pkts == 1)
+        shaper_activate_flow(ue, flow);
+    shaper_mark_ue_active(ue_idx);
+
+    rte_spinlock_unlock(&ue->lock);
+
+    __atomic_fetch_add(&g_shaper_queued, 1, __ATOMIC_RELAXED);
+    meta->action = ONVM_NF_ACTION_DROP;
+    return SHAPER_QUEUED;
+}
+
+static bool
+shaper_drain_one_from_list_locked(int ue_idx,
+                                  enum shaper_active_list_id list_id,
+                                  enum ue_bucket_class bucket_class,
+                                  struct rte_mbuf **tx_buf,
+                                  uint32_t *nb_tx,
+                                  struct onvm_configuration *onvm_config) {
+    struct ue_shaper *ue = &g_ue_shaper[ue_idx];
+    uint32_t attempts = ue->active_count[list_id];
+
+    while (attempts-- > 0) {
+        struct shaper_flow *flow = TAILQ_FIRST(&ue->active[list_id]);
+        struct shaper_entry *entry;
+        struct rte_mbuf *pkt;
+
+        if (flow == NULL)
+            return false;
+
+        shaper_deactivate_flow(ue, flow);
+        entry = flow->head;
+        if (entry == NULL) {
+            shaper_release_empty_flow(ue, flow);
+            continue;
+        }
+
+        if (!ueBucketCanFitPacket(ue_idx, bucket_class, entry->pkt_len)) {
+            flow->head = entry->next;
+            if (flow->head == NULL)
+                flow->tail = NULL;
+            flow->queued_pkts--;
+            flow->queued_bytes -= entry->pkt_len;
+            ue->queued_pkts--;
+            rte_pktmbuf_free(entry->pkt);
+            shaper_free_entry(entry);
+            __atomic_fetch_add(&g_shaper_drop_invalid, 1, __ATOMIC_RELAXED);
+            if (flow->head != NULL)
+                shaper_activate_flow(ue, flow);
+            else
+                shaper_release_empty_flow(ue, flow);
+            continue;
+        }
+
+        if (!consumeUeBucketTokens(ue_idx, bucket_class, entry->pkt_len)) {
+            shaper_activate_flow(ue, flow);
+            continue;
+        }
+
+        flow->head = entry->next;
+        if (flow->head == NULL)
+            flow->tail = NULL;
+        flow->queued_pkts--;
+        flow->queued_bytes -= entry->pkt_len;
+        ue->queued_pkts--;
+
+        pkt = entry->pkt;
+        struct onvm_pkt_meta *m =
+            onvm_get_pkt_meta(pkt, onvm_config->dynfield_offset);
+        m->action = ONVM_NF_ACTION_OUT;
+        m->destination = entry->destination;
+        tx_buf[(*nb_tx)++] = pkt;
+
+        shaper_free_entry(entry);
+        if (flow->head != NULL)
+            shaper_activate_flow(ue, flow);
+        else
+            shaper_release_empty_flow(ue, flow);
+
+        __atomic_fetch_add(&g_shaper_drained, 1, __ATOMIC_RELAXED);
+        return true;
+    }
+
+    return false;
+}
+
+static uint32_t
+shaper_drain_service_locked(int ue_idx,
+                            enum shaper_active_list_id list_id,
+                            enum ue_bucket_class bucket_class,
+                            struct rte_mbuf **tx_buf,
+                            uint32_t *nb_tx,
+                            struct onvm_configuration *onvm_config,
+                            uint32_t budget) {
+    uint32_t sent = 0;
+
+    while (sent < budget &&
+           g_ue_shaper[ue_idx].active_count[list_id] > 0) {
+        if (!shaper_drain_one_from_list_locked(ue_idx, list_id,
+                                               bucket_class, tx_buf, nb_tx,
+                                               onvm_config))
+            break;
+        sent++;
+    }
+
+    return sent;
+}
+
+static uint32_t
+shaper_drain_green_locked(int ue_idx, struct rte_mbuf **tx_buf,
+                          uint32_t *nb_tx,
+                          struct onvm_configuration *onvm_config,
+                          uint32_t budget) {
+    return shaper_drain_service_locked(ue_idx, SHAPER_ACTIVE_GREEN,
+                                       UE_BUCKET_GREEN, tx_buf, nb_tx,
+                                       onvm_config, budget);
+}
+
+static uint32_t
+shaper_drain_excess_locked(int ue_idx, struct rte_mbuf **tx_buf,
+                           uint32_t *nb_tx,
+                           struct onvm_configuration *onvm_config,
+                           uint32_t budget) {
+    struct ue_shaper *ue = &g_ue_shaper[ue_idx];
+    uint32_t sent = 0;
+
+    while (sent < budget &&
+           (ue->active_count[SHAPER_ACTIVE_YELLOW] > 0 ||
+            ue->active_count[SHAPER_ACTIVE_NQOS] > 0)) {
+        bool prefer_yellow = ue->next_excess_is_yellow != 0;
+        enum shaper_active_list_id list_id = prefer_yellow ?
+            SHAPER_ACTIVE_YELLOW : SHAPER_ACTIVE_NQOS;
+        enum ue_bucket_class bucket_class = prefer_yellow ?
+            UE_BUCKET_YELLOW : UE_BUCKET_NQOS;
+        uint32_t n;
+
+        n = shaper_drain_service_locked(ue_idx, list_id, bucket_class,
+                                        tx_buf, nb_tx, onvm_config, 1);
+        ue->next_excess_is_yellow = !ue->next_excess_is_yellow;
+        if (n == 0) {
+            list_id = prefer_yellow ? SHAPER_ACTIVE_NQOS :
+                                      SHAPER_ACTIVE_YELLOW;
+            bucket_class = prefer_yellow ? UE_BUCKET_NQOS :
+                                           UE_BUCKET_YELLOW;
+            n = shaper_drain_service_locked(ue_idx, list_id, bucket_class,
+                                            tx_buf, nb_tx, onvm_config, 1);
+            if (n == 0)
+                break;
+        }
+        sent += n;
+    }
+
+    return sent;
+}
+
+static uint32_t
+drain_ue_shaper(int ue_idx, struct onvm_nf *nf, uint32_t budget) {
+    struct rte_mbuf *tx_buf[DRAIN_CHUNK];
+    struct onvm_configuration *onvm_config;
+    struct ue_shaper *ue;
+    uint32_t nb_tx = 0;
+    uint32_t total = 0;
+
+    if (ue_idx < 0 || ue_idx >= MAX_UE || nf == NULL || budget == 0)
+        return 0;
+
+    ue = &g_ue_shaper[ue_idx];
+    onvm_config = onvm_nflib_get_onvm_config();
+    rte_spinlock_lock(&ue->lock);
+    if (ue->queued_pkts == 0) {
+        shaper_clear_ue_active(ue_idx);
+        rte_spinlock_unlock(&ue->lock);
+        return 0;
+    }
+
+    while (budget > 0 && nb_tx < DRAIN_CHUNK && ue->queued_pkts > 0) {
+        bool sent = false;
+        uint32_t tx_room = DRAIN_CHUNK - nb_tx;
+        uint32_t burst = RTE_MIN(budget, (uint32_t)SHAPER_CLASS_BURST);
+        uint32_t n;
+
+        burst = RTE_MIN(burst, tx_room);
+        if (burst == 0)
+            break;
+
+        n = shaper_drain_green_locked(ue_idx, tx_buf, &nb_tx,
+                                      onvm_config, burst);
+        if (n > 0) {
+            total += n;
+            budget -= n;
+            sent = true;
+            if (budget == 0 || nb_tx == DRAIN_CHUNK)
+                break;
+        }
+
+        tx_room = DRAIN_CHUNK - nb_tx;
+        burst = RTE_MIN(budget, (uint32_t)SHAPER_CLASS_BURST);
+        burst = RTE_MIN(burst, tx_room);
+        if (burst == 0)
+            break;
+
+        n = shaper_drain_excess_locked(ue_idx, tx_buf, &nb_tx,
+                                       onvm_config, burst);
+        if (n > 0) {
+            total += n;
+            budget -= n;
+            sent = true;
+        }
+
+        if (!sent)
+            break;
+    }
+    if (ue->queued_pkts == 0)
+        shaper_clear_ue_active(ue_idx);
+    else
+        shaper_mark_ue_active(ue_idx);
+    rte_spinlock_unlock(&ue->lock);
+
+    if (nb_tx > 0) {
+        onvm_pkt_process_tx_batch(nf->nf_tx_mgr, tx_buf,
+                                  onvm_config->dynfield_offset, nb_tx, nf);
+        onvm_pkt_enqueue_tx_thread(nf->nf_tx_mgr->to_tx_buf, nf);
+    }
+    return total;
+}
+
+static uint32_t
+drain_shaper_queues(struct onvm_nf *nf) {
+    uint64_t tried_ue_bitmap[SHAPER_UE_BITMAP_WORDS] = {0};
+    uint32_t total = 0;
+    uint32_t budget = SHAPER_DRAIN_BUDGET;
+
+    for (uint32_t visited = 0; visited < SHAPER_SCAN_BUDGET && budget > 0; visited++) {
+        int ue_idx = shaper_next_active_ue(tried_ue_bitmap);
+        uint32_t drained;
+
+        if (ue_idx < 0)
+            break;
+
+        tried_ue_bitmap[(uint32_t)ue_idx / 64] |=
+            1ULL << ((uint32_t)ue_idx & 63);
+        drained = drain_ue_shaper(ue_idx, nf, budget);
+        total += drained;
+        budget -= drained;
+    }
+
+    return total;
+}
+
+static void
+shaper_cleanup(void) {
+    for (int ue_idx = 0; ue_idx < MAX_UE; ue_idx++) {
+        struct ue_shaper *ue = &g_ue_shaper[ue_idx];
+
+        rte_spinlock_lock(&ue->lock);
+        for (int flow_idx = 0; flow_idx < SHAPER_MAX_FLOWS_PER_UE; flow_idx++) {
+            struct shaper_flow *flow = &ue->flows[flow_idx];
+            struct shaper_entry *entry = flow->head;
+
+            while (entry != NULL) {
+                struct shaper_entry *next = entry->next;
+                if (entry->pkt != NULL)
+                    rte_pktmbuf_free(entry->pkt);
+                shaper_free_entry(entry);
+                entry = next;
+            }
+            memset(flow, 0, sizeof(*flow));
+        }
+        ue->queued_pkts = 0;
+        ue->next_excess_is_yellow = 1;
+        for (int list_id = 0; list_id < SHAPER_ACTIVE_COUNT; list_id++) {
+            TAILQ_INIT(&ue->active[list_id]);
+            ue->active_count[list_id] = 0;
+        }
+        rte_spinlock_unlock(&ue->lock);
+    }
+    for (uint32_t word_idx = 0; word_idx < SHAPER_UE_BITMAP_WORDS; word_idx++)
+        __atomic_store_n(&g_shaper_active_ue_bitmap[word_idx], 0,
+                         __ATOMIC_RELEASE);
+    g_shaper_active_ue_cursor = 0;
+}
+
+static bool
+build_dl_shaper_flow_key(struct rte_mbuf *pkt, const UPDK_PDR *pdr,
+                         uint32_t ue_ip, bool is_qos,
+                         struct shaper_flow_key *key) {
+    struct rte_ipv4_hdr *iph;
+    uint16_t l4_off;
+    uint32_t pkt_len;
+
+    if (pkt == NULL || key == NULL)
+        return false;
+
+    iph = onvm_pkt_ipv4_hdr(pkt);
+    if (iph == NULL || ((iph->version_ihl >> 4) != 4))
+        return false;
+
+    memset(key, 0, sizeof(*key));
+    key->ue_ip = ue_ip;
+    key->src_ip = rte_be_to_cpu_32(iph->src_addr);
+    key->dst_ip = rte_be_to_cpu_32(iph->dst_addr);
+    key->proto = iph->next_proto_id;
+    key->is_qos = is_qos ? 1 : 0;
+    key->qfi = (is_qos && pdr != NULL && pdr->qer != NULL) ?
+               QERGetQFI(pdr->qer) : 0;
+
+    l4_off = sizeof(struct rte_ether_hdr) +
+             ((iph->version_ihl & 0x0f) * 4);
+    pkt_len = rte_pktmbuf_pkt_len(pkt);
+    if (key->proto == IPPROTO_UDP &&
+        pkt_len >= l4_off + sizeof(struct rte_udp_hdr)) {
+        struct rte_udp_hdr udp_hdr;
+        const struct rte_udp_hdr *uh =
+            rte_pktmbuf_read(pkt, l4_off, sizeof(udp_hdr), &udp_hdr);
+        if (uh == NULL)
+            return false;
+        key->src_port = rte_be_to_cpu_16(uh->src_port);
+        key->dst_port = rte_be_to_cpu_16(uh->dst_port);
+    } else if (key->proto == IPPROTO_TCP &&
+               pkt_len >= l4_off + sizeof(struct rte_tcp_hdr)) {
+        struct rte_tcp_hdr tcp_hdr;
+        const struct rte_tcp_hdr *th =
+            rte_pktmbuf_read(pkt, l4_off, sizeof(tcp_hdr), &tcp_hdr);
+        if (th == NULL)
+            return false;
+        key->src_port = rte_be_to_cpu_16(th->src_port);
+        key->dst_port = rte_be_to_cpu_16(th->dst_port);
+    }
+
+    return true;
 }
 
 UPDK_PDR *
@@ -525,6 +1301,9 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
     UPDK_PDR *pdr = NULL;
     gtp_parse_result_t gtp_info = {0};
     int ue_idx = -1;
+    UpfSession *owner_session = NULL;
+    uint32_t ue_key = 0;
+    struct shaper_flow_key dl_flow_key = {0};
 
     /* char *src_address = convertToIpAddressString(iph->src_addr);
     UTLT_Info("Src IP is %s\n", src_address);
@@ -558,10 +1337,16 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
     UTLT_Info("Got PDR ID is %u\n", pdr->pdrId);
 
     if (is_dl) {
-        uint32_t ue_key = rte_cpu_to_be_32(iph->dst_addr);
+        ue_key = rte_cpu_to_be_32(iph->dst_addr);
         ue_idx = findIndexByUeIpAddress(ue_key);
         if (ue_idx < 0) {
             ue_idx = GetQerByUEIpAddressFromPdr(ue_key, pdr, convertToIpAddressString(iph->dst_addr));
+        }
+        if (!build_dl_shaper_flow_key(pkt, pdr, ue_key, pdr->has_fd,
+                                      &dl_flow_key)) {
+            UTLT_Error("Failed to build DL shaper flow key");
+            meta->action = ONVM_NF_ACTION_DROP;
+            return 0;
         }
     }
 
@@ -658,7 +1443,9 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
             goto dl_nocp;
         }
 
-        /* QoS policing — FORW only */
+        /* QoS shaping — FORW only, after GTP-U/L2 TX prep is complete.
+         * Over-token packets wait in bounded per-flow FIFOs; only red,
+         * invalid, or queue-overflow packets drop. */
         if (far_action == UPDK_FAR_APPLY_ACTION_FORW) {
             if (ue_idx < 0) {
                 UTLT_Error("No UE IP found in the table");
@@ -693,24 +1480,27 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
             if (isQos) {
                 if (meta->flags == RTE_COLOR_RED) {
                     meta->action = ONVM_NF_ACTION_DROP;
+                    __atomic_fetch_add(&g_shaper_drop_red, 1, __ATOMIC_RELAXED);
                     goto dl_nocp;
                 }
-                if (meta->flags == RTE_COLOR_GREEN) {
-                    ue_table[ue_idx].ue_qos_tb_params.tb_tokens -= cal_pktlen;
-                }
-                if (meta->flags == RTE_COLOR_YELLOW) {
-                    while (ue_table[ue_idx].ue_qos_tb_params.tb_tokens < cal_pktlen) {
-                        updateTokenbyIndex(ue_idx);
-                        usleep(1);
-                    }
-                    ue_table[ue_idx].ue_qos_tb_params.tb_tokens -= cal_pktlen;
+                if (meta->flags == RTE_COLOR_GREEN ||
+                    meta->flags == RTE_COLOR_YELLOW) {
+                    enum shaper_pkt_color color =
+                        (meta->flags == RTE_COLOR_GREEN) ?
+                        SHAPER_COLOR_GREEN : SHAPER_COLOR_YELLOW;
+                    enum shaper_decision decision =
+                        shape_or_enqueue_packet(ue_idx, &dl_flow_key, true,
+                                                color, pkt, cal_pktlen, meta);
+                    if (decision != SHAPER_PASS)
+                        goto dl_nocp;
                 }
             } else {
-                while (ue_table[ue_idx].ue_nqos_tb_params.tb_tokens < cal_pktlen) {
-                    updateTokenbyIndex(ue_idx);
-                    usleep(1);
-                }
-                ue_table[ue_idx].ue_nqos_tb_params.tb_tokens -= cal_pktlen;
+                enum shaper_decision decision =
+                    shape_or_enqueue_packet(ue_idx, &dl_flow_key, false,
+                                            SHAPER_COLOR_NQOS, pkt,
+                                            cal_pktlen, meta);
+                if (decision != SHAPER_PASS)
+                    goto dl_nocp;
             }
         }
 
@@ -831,6 +1621,48 @@ msg_handler(void *msg_data, struct onvm_nf_local_ctx *nf_local_ctx) {
     if (e) rte_free(e);
 }
 
+static uint64_t last_p = 0;
+
+static int
+callback_handler(struct onvm_nf_local_ctx *nf_local_ctx) {
+    if (unlikely(!last_p)) last_p = rte_get_tsc_cycles();
+    uint64_t cur_p = rte_get_tsc_cycles();
+    struct onvm_nf *nf = nf_local_ctx->nf;
+
+    drain_shaper_queues(nf);
+
+    if (unlikely(cur_p - last_p > rte_get_timer_hz())) {
+        last_p = cur_p;
+        UTLT_Debug("Stats perform: ");
+        UTLT_Debug("act out: %d", nf->stats.act_out);
+        UTLT_Debug("buffered: %d", nf->stats.tx_buffer);
+        UTLT_Debug("shaper queued: %" PRIu64,
+                   __atomic_load_n(&g_shaper_queued, __ATOMIC_RELAXED));
+        UTLT_Debug("shaper drained: %" PRIu64,
+                   __atomic_load_n(&g_shaper_drained, __ATOMIC_RELAXED));
+        UTLT_Debug("shaper invalid drops: %" PRIu64,
+                   __atomic_load_n(&g_shaper_drop_invalid, __ATOMIC_RELAXED));
+        UTLT_Debug("shaper red drops: %" PRIu64,
+                   __atomic_load_n(&g_shaper_drop_red, __ATOMIC_RELAXED));
+        UTLT_Debug("shaper green overflow drops: %" PRIu64,
+                   __atomic_load_n(&g_shaper_drop_green_overflow, __ATOMIC_RELAXED));
+        UTLT_Debug("shaper yellow overflow drops: %" PRIu64,
+                   __atomic_load_n(&g_shaper_drop_yellow_overflow, __ATOMIC_RELAXED));
+        UTLT_Debug("shaper non-QoS overflow drops: %" PRIu64,
+                   __atomic_load_n(&g_shaper_drop_nqos_overflow, __ATOMIC_RELAXED));
+        UTLT_Debug("shaper flow table full drops: %" PRIu64,
+                   __atomic_load_n(&g_shaper_drop_flow_table_full, __ATOMIC_RELAXED));
+        UTLT_Debug("shaper flow queue full drops: %" PRIu64,
+                   __atomic_load_n(&g_shaper_drop_flow_queue_full, __ATOMIC_RELAXED));
+        UTLT_Debug("shaper UE queue full drops: %" PRIu64,
+                   __atomic_load_n(&g_shaper_drop_ue_queue_full, __ATOMIC_RELAXED));
+        UTLT_Debug("shaper mempool empty drops: %" PRIu64,
+                   __atomic_load_n(&g_shaper_drop_mempool_empty, __ATOMIC_RELAXED));
+    }
+
+    return 0;
+}
+
 int
 main(int argc, char *argv[]) {
     int arg_offset;
@@ -843,6 +1675,7 @@ main(int argc, char *argv[]) {
     nf_function_table = onvm_nflib_init_nf_function_table();
     nf_function_table->pkt_handler = &packet_handler;
     nf_function_table->msg_handler = &msg_handler;
+    nf_function_table->user_actions = &callback_handler;
 
     if ((arg_offset = onvm_nflib_init(argc, argv, NF_TAG, nf_local_ctx, nf_function_table)) < 0) {
         onvm_nflib_stop(nf_local_ctx);
@@ -897,8 +1730,14 @@ main(int argc, char *argv[]) {
         rte_exit(EXIT_FAILURE, "failed to init ARP module\n");
     }
 
+    shaper_init_state();
+    if (shaper_init_entry_pool(nf_local_ctx->nf) < 0) {
+        rte_exit(EXIT_FAILURE, "Failed to init UPF-U shaper entry pool.\n");
+    }
+
     onvm_nflib_run(nf_local_ctx);
 
+    shaper_cleanup();
     onvm_nflib_stop(nf_local_ctx);
     return 0;
 }

--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -68,15 +68,15 @@
 
 /* Used for buffering */
 #define INLINE_DRAIN_BATCH       8    /* pkts drained per INLINE (FORW)  */
-#define DRAIN_CHUNK             64    /* max pkts dequeued per drain call */
+#define DRAIN_CHUNK             128   /* max pkts dequeued per drain call */
 
 /* Used for non-blocking UE token-bucket shaping */
 #define SHAPER_SCAN_BUDGET       32
-#define SHAPER_DRAIN_BUDGET      64
-#define SHAPER_CLASS_BURST        8
+#define SHAPER_DRAIN_BUDGET      128
+#define SHAPER_CLASS_BURST        16
 #define SHAPER_MAX_FLOWS_PER_UE  64
-#define SHAPER_MAX_PKTS_PER_FLOW 256
-#define SHAPER_MAX_PKTS_PER_UE   1024
+#define SHAPER_MAX_PKTS_PER_FLOW 512
+#define SHAPER_MAX_PKTS_PER_UE   2048
 #define SHAPER_ENTRY_POOL_CACHE  256
 #define SHAPER_UE_BITMAP_WORDS   ((MAX_UE + 63) / 64)
 

--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -1105,11 +1105,86 @@ GetPdrByTeid(struct rte_mbuf *pkt, const gtp_parse_result_t *gtp_info) {
     return pdr;
 }
 
-/* Populate UE table using the already-classified UPDK_PDR (no session/pdr_list scan)*/
-static inline int
-GetQerByUEIpAddressFromPdr(uint32_t ue_ip, const UPDK_PDR *pdr, const char *ip_str)
+static inline void
+AccumulateQerDlRates(const UPDK_QER *q, uint64_t *ambr64,
+                     uint64_t *gbr64, uint64_t *mbr64,
+                     bool *has_gbr_qer)
 {
-    if (!pdr || pdr->qer_count == 0) {
+    if (!q || !q->flags.maximumBitrate)
+        return;
+
+    if (q->flags.guaranteedBitrate) {
+        *has_gbr_qer = true;
+        *gbr64 = saturating_add_u64(*gbr64, q->guaranteedBitrate.dl);
+        *mbr64 = saturating_add_u64(*mbr64, q->maximumBitrate.dl);
+        return;
+    }
+
+    if (q->maximumBitrate.dl > *ambr64)
+        *ambr64 = q->maximumBitrate.dl;
+}
+
+static inline bool
+GetQerRatesFromSession(UpfSession *session, uint64_t *ambr64,
+                       uint64_t *gbr64, uint64_t *mbr64,
+                       bool *has_gbr_qer)
+{
+    list_iterator_t *it;
+    list_node_t *node;
+    bool found = false;
+
+    if (!session || !session->qer_list)
+        return false;
+
+    it = list_iterator_new(session->qer_list, LIST_HEAD);
+    if (!it)
+        return false;
+
+    while ((node = list_iterator_next(it)) != NULL) {
+        const UPDK_QER *q = (const UPDK_QER *)node->val;
+        if (!q || !q->flags.maximumBitrate)
+            continue;
+
+        found = true;
+        AccumulateQerDlRates(q, ambr64, gbr64, mbr64, has_gbr_qer);
+    }
+
+    list_iterator_destroy(it);
+    return found;
+}
+
+static inline bool
+GetQerRatesFromPdr(const UPDK_PDR *pdr, uint64_t *ambr64,
+                   uint64_t *gbr64, uint64_t *mbr64,
+                   bool *has_gbr_qer)
+{
+    bool found = false;
+
+    if (!pdr || pdr->qer_count == 0)
+        return false;
+
+    int n = (int)pdr->qer_count;
+    if (n > 2) n = 2; /* safety; struct currently supports 2 */
+
+    for (int i = 0; i < n; i++) {
+        const UPDK_QER *q = pdr->qers[i];
+        if (!q || !q->flags.maximumBitrate)
+            continue;
+
+        found = true;
+        AccumulateQerDlRates(q, ambr64, gbr64, mbr64, has_gbr_qer);
+    }
+
+    return found;
+}
+
+/* Populate UE table from the owning session when possible. The session-level
+ * non-GBR QER carries AMBR; GBR-bearing QERs carry QoS flow GBR/MBR. */
+static inline int
+GetQerByUEIpAddressFromPdr(uint32_t ue_ip, UpfSession *session,
+                           const UPDK_PDR *pdr, const char *ip_str)
+{
+    if ((!session || !session->qer_list) && (!pdr || pdr->qer_count == 0)) {
         UTLT_Trace("UE %s: No PDR or PDR has no QERs, skip UE table entry",
                    ip_str ? ip_str : "<unknown>");
         return -1;
@@ -1120,22 +1195,12 @@ GetQerByUEIpAddressFromPdr(uint32_t ue_ip, const UPDK_PDR *pdr, const char *ip_s
     uint64_t mbr64  = 0;
     bool has_gbr_qer = false;
 
-    int n = (int)pdr->qer_count;
-    if (n > 2) n = 2; /* safety; struct currently supports 2 */
-
-    for (int i = 0; i < n; i++) {
-        const UPDK_QER *q = pdr->qers[i];
-        if (!q) continue;
-
-        if (q->flags.maximumBitrate && q->maximumBitrate.dl > ambr64)
-            ambr64 = q->maximumBitrate.dl;
-
-        if (q->flags.guaranteedBitrate && q->flags.maximumBitrate) {
-            has_gbr_qer = true;
-            gbr64 = saturating_add_u64(gbr64, q->guaranteedBitrate.dl);
-            mbr64 = saturating_add_u64(mbr64, q->maximumBitrate.dl);
-        }
+    if (!GetQerRatesFromSession(session, &ambr64, &gbr64, &mbr64,
+                                &has_gbr_qer)) {
+        GetQerRatesFromPdr(pdr, &ambr64, &gbr64, &mbr64, &has_gbr_qer);
     }
+    if (ambr64 == 0 && mbr64 > 0)
+        ambr64 = mbr64;
 
     if (ambr64 == 0) {
         UTLT_Trace("UE %s: no DL MBR across PDR QERs, skip UE table entry",
@@ -1390,7 +1455,8 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
         ue_key = rte_cpu_to_be_32(iph->dst_addr);
         ue_idx = findIndexByUeIpAddress(ue_key);
         if (ue_idx < 0) {
-            ue_idx = GetQerByUEIpAddressFromPdr(ue_key, pdr, convertToIpAddressString(iph->dst_addr));
+            ue_idx = GetQerByUEIpAddressFromPdr(ue_key, owner_session, pdr,
+                                                convertToIpAddressString(iph->dst_addr));
         }
         if (!build_dl_shaper_flow_key(pkt, pdr, ue_key, pdr->has_fd,
                                       &dl_flow_key)) {

--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -955,6 +955,60 @@ build_dl_shaper_flow_key(struct rte_mbuf *pkt, const UPDK_PDR *pdr,
     return true;
 }
 
+static uint32_t
+dl_qos_packet_len(struct rte_mbuf *pkt, const struct rte_ipv4_hdr *iph) {
+    uint16_t ip_total_len;
+    uint16_t ip_hdr_len;
+    uint16_t l4_payload_len;
+    uint16_t l4_off;
+    uint32_t pkt_len;
+
+    if (pkt == NULL || iph == NULL)
+        return 0;
+
+    ip_hdr_len = (uint16_t)((iph->version_ihl & 0x0f) * 4);
+    ip_total_len = rte_be_to_cpu_16(iph->total_length);
+    pkt_len = rte_pktmbuf_pkt_len(pkt);
+
+    if (ip_hdr_len < sizeof(struct rte_ipv4_hdr) ||
+        ip_total_len < ip_hdr_len ||
+        pkt_len < sizeof(struct rte_ether_hdr) + ip_hdr_len)
+        return 0;
+
+    l4_payload_len = ip_total_len - ip_hdr_len;
+    l4_off = sizeof(struct rte_ether_hdr) + ip_hdr_len;
+
+    if (iph->next_proto_id == IPPROTO_UDP) {
+        if (l4_payload_len >= sizeof(struct rte_udp_hdr) &&
+            pkt_len >= l4_off + sizeof(struct rte_udp_hdr))
+            return l4_payload_len - sizeof(struct rte_udp_hdr);
+        return l4_payload_len;
+    }
+
+    if (iph->next_proto_id == IPPROTO_TCP) {
+        struct rte_tcp_hdr tcp_hdr;
+        const struct rte_tcp_hdr *th;
+        uint16_t tcp_hdr_len;
+
+        if (l4_payload_len < sizeof(struct rte_tcp_hdr) ||
+            pkt_len < l4_off + sizeof(struct rte_tcp_hdr))
+            return l4_payload_len;
+
+        th = rte_pktmbuf_read(pkt, l4_off, sizeof(tcp_hdr), &tcp_hdr);
+        if (th == NULL)
+            return l4_payload_len;
+
+        tcp_hdr_len = (uint16_t)((th->data_off >> 4) * 4);
+        if (tcp_hdr_len < sizeof(struct rte_tcp_hdr) ||
+            tcp_hdr_len > l4_payload_len)
+            return l4_payload_len;
+
+        return l4_payload_len - tcp_hdr_len;
+    }
+
+    return l4_payload_len;
+}
+
 static inline uint64_t
 saturating_add_u64(uint64_t lhs, uint64_t rhs) {
     return UINT64_MAX - lhs < rhs ? UINT64_MAX : lhs + rhs;
@@ -1291,7 +1345,6 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
     uint32_t cal_pktlen = 0;
     UTLT_Trace("Get packet\n");
     UTLT_Info("Handle PKT from port: %d [len: %d]", pkt->port, pkt->pkt_len);
-    cal_pktlen = pkt->pkt_len - sizeof(struct rte_ether_hdr) - sizeof(struct rte_ipv4_hdr) - sizeof(struct rte_udp_hdr);
 
     bool is_dl = false;
     meta->action = ONVM_NF_ACTION_DROP;
@@ -1302,6 +1355,7 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
         UTLT_Info("Not IP packet, ignore it\n");
         return 0;
     }
+    cal_pktlen = dl_qos_packet_len(pkt, iph);
 
     // Flip to a newly published snapshot if a REQ was received
     UpfClsMaybeFlipAndAck();

--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -595,13 +595,6 @@ shape_or_enqueue_packet(int ue_idx, const struct shaper_flow_key *key,
         shaper_count_overflow(color);
         return SHAPER_DROP;
     }
-    if (pkt_len == 0)
-        pkt_len = rte_pktmbuf_pkt_len(pkt);
-    if (pkt_len == 0) {
-        meta->action = ONVM_NF_ACTION_DROP;
-        __atomic_fetch_add(&g_shaper_drop_invalid, 1, __ATOMIC_RELAXED);
-        return SHAPER_DROP;
-    }
     min_queue_bytes = (uint64_t)pkt_len * SHAPER_MIN_QUEUE_PKTS;
 
     if (!ueBucketCanFitPacket(ue_idx, bucket_class, pkt_len)) {
@@ -1018,16 +1011,19 @@ build_dl_shaper_flow_key(struct rte_mbuf *pkt, const UPDK_PDR *pdr,
     return true;
 }
 
-static uint32_t
-dl_qos_packet_len(struct rte_mbuf *pkt, const struct rte_ipv4_hdr *iph) {
+static bool
+dl_qos_packet_len(struct rte_mbuf *pkt, const struct rte_ipv4_hdr *iph,
+                  uint32_t *metered_len) {
     uint16_t ip_total_len;
     uint16_t ip_hdr_len;
     uint16_t l4_payload_len;
     uint16_t l4_off;
     uint32_t pkt_len;
 
-    if (pkt == NULL || iph == NULL)
-        return 0;
+    if (metered_len != NULL)
+        *metered_len = 0;
+    if (pkt == NULL || iph == NULL || metered_len == NULL)
+        return false;
 
     ip_hdr_len = (uint16_t)((iph->version_ihl & 0x0f) * 4);
     ip_total_len = rte_be_to_cpu_16(iph->total_length);
@@ -1035,17 +1031,17 @@ dl_qos_packet_len(struct rte_mbuf *pkt, const struct rte_ipv4_hdr *iph) {
 
     if (ip_hdr_len < sizeof(struct rte_ipv4_hdr) ||
         ip_total_len < ip_hdr_len ||
-        pkt_len < sizeof(struct rte_ether_hdr) + ip_hdr_len)
-        return 0;
+        pkt_len < sizeof(struct rte_ether_hdr) + ip_total_len)
+        return false;
 
     l4_payload_len = ip_total_len - ip_hdr_len;
     l4_off = sizeof(struct rte_ether_hdr) + ip_hdr_len;
 
     if (iph->next_proto_id == IPPROTO_UDP) {
-        if (l4_payload_len >= sizeof(struct rte_udp_hdr) &&
-            pkt_len >= l4_off + sizeof(struct rte_udp_hdr))
-            return l4_payload_len - sizeof(struct rte_udp_hdr);
-        return l4_payload_len;
+        if (l4_payload_len < sizeof(struct rte_udp_hdr))
+            return false;
+        *metered_len = l4_payload_len - sizeof(struct rte_udp_hdr);
+        return true;
     }
 
     if (iph->next_proto_id == IPPROTO_TCP) {
@@ -1053,23 +1049,24 @@ dl_qos_packet_len(struct rte_mbuf *pkt, const struct rte_ipv4_hdr *iph) {
         const struct rte_tcp_hdr *th;
         uint16_t tcp_hdr_len;
 
-        if (l4_payload_len < sizeof(struct rte_tcp_hdr) ||
-            pkt_len < l4_off + sizeof(struct rte_tcp_hdr))
-            return l4_payload_len;
+        if (l4_payload_len < sizeof(struct rte_tcp_hdr))
+            return false;
 
         th = rte_pktmbuf_read(pkt, l4_off, sizeof(tcp_hdr), &tcp_hdr);
         if (th == NULL)
-            return l4_payload_len;
+            return false;
 
         tcp_hdr_len = (uint16_t)((th->data_off >> 4) * 4);
         if (tcp_hdr_len < sizeof(struct rte_tcp_hdr) ||
             tcp_hdr_len > l4_payload_len)
-            return l4_payload_len;
+            return false;
 
-        return l4_payload_len - tcp_hdr_len;
+        *metered_len = l4_payload_len - tcp_hdr_len;
+        return true;
     }
 
-    return l4_payload_len;
+    *metered_len = l4_payload_len;
+    return true;
 }
 
 static inline uint64_t
@@ -1474,6 +1471,7 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
     }
 
     uint32_t cal_pktlen = 0;
+    bool cal_pktlen_valid = false;
     UTLT_Trace("Get packet\n");
     UTLT_Info("Handle PKT from port: %d [len: %d]", pkt->port, pkt->pkt_len);
 
@@ -1486,7 +1484,7 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
         UTLT_Info("Not IP packet, ignore it\n");
         return 0;
     }
-    cal_pktlen = dl_qos_packet_len(pkt, iph);
+    cal_pktlen_valid = dl_qos_packet_len(pkt, iph, &cal_pktlen);
 
     // Flip to a newly published snapshot if a REQ was received
     UpfClsMaybeFlipAndAck();
@@ -1531,6 +1529,13 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
 
     if (is_dl) {
         ue_key = rte_cpu_to_be_32(iph->dst_addr);
+        if (!cal_pktlen_valid) {
+            UTLT_Warning("Invalid DL IPv4/L4 length for UE %s, drop",
+                         convertToIpAddressString(iph->dst_addr));
+            meta->action = ONVM_NF_ACTION_DROP;
+            return 0;
+        }
+        owner_session = UpfSessionFindByUeIP(ue_key);
         ue_idx = findIndexByUeIpAddress(ue_key);
         if (ue_idx < 0) {
             ue_idx = GetQerByUEIpAddressFromPdr(ue_key, owner_session, pdr,
@@ -1845,9 +1850,15 @@ static uint64_t last_p = 0;
 
 static int
 callback_handler(struct onvm_nf_local_ctx *nf_local_ctx) {
+    struct onvm_nf *nf;
+    uint64_t cur_p;
+
+    if (unlikely(nf_local_ctx == NULL || nf_local_ctx->nf == NULL))
+        return 0;
+
+    nf = nf_local_ctx->nf;
     if (unlikely(!last_p)) last_p = rte_get_tsc_cycles();
-    uint64_t cur_p = rte_get_tsc_cycles();
-    struct onvm_nf *nf = nf_local_ctx->nf;
+    cur_p = rte_get_tsc_cycles();
 
     drain_shaper_queues(nf);
 

--- a/5gc/upf_u/upf_u_trtcm.c
+++ b/5gc/upf_u/upf_u_trtcm.c
@@ -38,6 +38,7 @@ uint32_t trTCMidx = 0;
 struct rte_meter_trtcm_profile app_trtcm_profile;
 struct rte_meter_trtcm_profile app_flow_trtcm_profiles[APP_FLOWS_MAX];
 struct rte_meter_trtcm app_flows[APP_FLOWS_MAX];
+static bool app_flow_has_gbr[APP_FLOWS_MAX];
 
 static struct ue_hash_entry ue_hash[MAX_UE];
 struct ue_tb ue_table[MAX_UE];
@@ -68,6 +69,7 @@ trtcmConfigFlowTables(void) {
     // config flow meters with trtcm profiles
     for (i = 0; i < APP_FLOWS_MAX; i++){
         app_flow_trtcm_profiles[i] = app_trtcm_profile;
+        app_flow_has_gbr[i] = true;
         rtn = rte_meter_trtcm_config(&app_flows[i],
                                      &app_flow_trtcm_profiles[i]);
         if (rtn)
@@ -99,6 +101,8 @@ trtcmColorHandle(uint32_t pkt_len, uint64_t time, int flow_idx, struct rte_meter
         target_profile,
         time,
         pkt_len);
+    if (!app_flow_has_gbr[flow_idx] && out_color == RTE_COLOR_GREEN)
+        out_color = RTE_COLOR_YELLOW;
     return out_color;
 }
 
@@ -365,11 +369,12 @@ ConfigureQerFlows(const UPDK_PDR *pdr, bool is_uplink) {
     UTLT_Info("QER ID: %u key: %u", qer->qerId, key);
 
     struct rte_meter_trtcm_params trtcm_params = app_trtcm_params;
+    bool has_gbr = qer->flags.guaranteedBitrate;
 
     uint32_t mbr = is_uplink ? qer->maximumBitrate.ul : qer->maximumBitrate.dl;
     trtcm_params.pir = mbr * 1000 / 8;
 
-    if (qer->flags.guaranteedBitrate) {
+    if (has_gbr) {
         uint32_t gbr = is_uplink ? qer->guaranteedBitrate.ul : qer->guaranteedBitrate.dl;
         trtcm_params.cir = gbr * 1000 / 8;
     } else {
@@ -388,6 +393,7 @@ ConfigureQerFlows(const UPDK_PDR *pdr, bool is_uplink) {
         UTLT_Warning("TRTCM flow config failed for key %u: %d", key, rtn);
         return;
     }
+    app_flow_has_gbr[trTCMidx] = has_gbr;
 
     if (!ftAddEntry(key, trTCMidx)) {
         UTLT_Warning("FT add failed");

--- a/5gc/upf_u/upf_u_trtcm.c
+++ b/5gc/upf_u/upf_u_trtcm.c
@@ -36,7 +36,7 @@ uint32_t iPFlowsLen = 0;
 uint32_t trTCMidx = 0;
 
 struct rte_meter_trtcm_profile app_trtcm_profile;
-struct rte_meter_trtcm_profile app_flow_trtcm_profile;
+struct rte_meter_trtcm_profile app_flow_trtcm_profiles[APP_FLOWS_MAX];
 struct rte_meter_trtcm app_flows[APP_FLOWS_MAX];
 
 static struct ue_hash_entry ue_hash[MAX_UE];
@@ -67,7 +67,9 @@ trtcmConfigFlowTables(void) {
 
     // config flow meters with trtcm profiles
     for (i = 0; i < APP_FLOWS_MAX; i++){
-        rtn = rte_meter_trtcm_config(&app_flows[i], &app_trtcm_profile);
+        app_flow_trtcm_profiles[i] = app_trtcm_profile;
+        rtn = rte_meter_trtcm_config(&app_flows[i],
+                                     &app_flow_trtcm_profiles[i]);
         if (rtn)
             return rtn;
     }
@@ -77,22 +79,35 @@ trtcmConfigFlowTables(void) {
 }
 
 int
-trtcmColorHandle(uint32_t pkt_len, uint64_t time, uint8_t qfi, struct rte_meter_trtcm_profile *target_profile) {
+trtcmColorHandle(uint32_t pkt_len, uint64_t time, int flow_idx, struct rte_meter_trtcm_profile *target_profile) {
     uint8_t out_color = 0;
     // check configured flow
-    if (unlikely(app_trtcm_profile.cir_period == 0)) {
+    if (unlikely(flow_idx < 0 || flow_idx >= (int)APP_FLOWS_MAX ||
+                 target_profile == NULL)) {
+        UTLT_Info("flow index/profile set err");
+        return -1;
+    }
+    if (unlikely(target_profile->cir_period == 0)) {
         UTLT_Info("flow cir_period set err");
         return -1;
     }
-    if (unlikely(app_trtcm_profile.pir_period == 0)) {
+    if (unlikely(target_profile->pir_period == 0)) {
         UTLT_Info("flow pir_period set err");
         return -1;
     }
-    out_color = (uint8_t) rte_meter_trtcm_color_blind_check(&app_flows[qfi],
+    out_color = (uint8_t) rte_meter_trtcm_color_blind_check(&app_flows[flow_idx],
         target_profile,
         time,
         pkt_len);
     return out_color;
+}
+
+struct rte_meter_trtcm_profile *
+trtcmProfileForFlow(int flow_idx) {
+    if (unlikely(flow_idx < 0 || flow_idx >= (int)APP_FLOWS_MAX))
+        return NULL;
+
+    return &app_flow_trtcm_profiles[flow_idx];
 }
 
 int
@@ -342,6 +357,10 @@ ConfigureQerFlows(const UPDK_PDR *pdr, bool is_uplink) {
 
     /* Only add on first miss — subsequent packets for the same key are a no-op */
     if (ftSearch(key) >= 0) return;
+    if (unlikely(trTCMidx >= APP_FLOWS_MAX)) {
+        UTLT_Warning("TRTCM flow table full; cannot add key %u", key);
+        return;
+    }
 
     UTLT_Info("QER ID: %u key: %u", qer->qerId, key);
 
@@ -357,20 +376,24 @@ ConfigureQerFlows(const UPDK_PDR *pdr, bool is_uplink) {
         trtcm_params.cir = 1;
     }
 
+    int rtn = rte_meter_trtcm_profile_config(&app_flow_trtcm_profiles[trTCMidx],
+                                             &trtcm_params);
+    if (rtn) {
+        UTLT_Warning("TRTCM profile config failed for key %u: %d", key, rtn);
+        return;
+    }
+    rtn = rte_meter_trtcm_config(&app_flows[trTCMidx],
+                                 &app_flow_trtcm_profiles[trTCMidx]);
+    if (rtn) {
+        UTLT_Warning("TRTCM flow config failed for key %u: %d", key, rtn);
+        return;
+    }
+
     if (!ftAddEntry(key, trTCMidx)) {
         UTLT_Warning("FT add failed");
+        return;
     }
     UTLT_Info("Successfully add %u(%d) %u", key, hashFunc(key), trTCMidx);
-
-    // Match config profile to what color-check later uses:
-    // SDF present (has_fd) → app_flow_trtcm_profile; else app_trtcm_profile
-    if (has_fd) {
-        rte_meter_trtcm_profile_config(&app_flow_trtcm_profile, &trtcm_params);
-        rte_meter_trtcm_config(&app_flows[trTCMidx], &app_flow_trtcm_profile);
-    } else {
-        rte_meter_trtcm_profile_config(&app_trtcm_profile, &trtcm_params);
-        rte_meter_trtcm_config(&app_flows[trTCMidx], &app_trtcm_profile);
-    }
 
     if (is_uplink) {
         UTLT_Info("Find MBR (UL: %lu) in QERs", qer->maximumBitrate.ul);

--- a/5gc/upf_u/upf_u_trtcm.c
+++ b/5gc/upf_u/upf_u_trtcm.c
@@ -30,6 +30,7 @@
 
 #define MIN_TOKEN_BUCKET_DEPTH 2048
 #define TOKEN_BUCKET_BURST_MS 10
+#define TRTCM_BURST_MS 100
 
 flow_entry_t iPFlows[APP_FLOWS_MAX];
 uint32_t iPFlowsLen = 0;
@@ -277,6 +278,18 @@ shaper_bucket_depth(uint32_t rate_kbps) {
            MIN_TOKEN_BUCKET_DEPTH : depth_bytes;
 }
 
+static inline uint64_t
+trtcm_bucket_depth(uint32_t rate_kbps) {
+    uint64_t depth_bytes;
+
+    if (rate_kbps == 0)
+        return MIN_TOKEN_BUCKET_DEPTH;
+
+    depth_bytes = ((uint64_t)rate_kbps * TRTCM_BURST_MS + 7) / 8;
+    return depth_bytes < MIN_TOKEN_BUCKET_DEPTH ?
+           MIN_TOKEN_BUCKET_DEPTH : depth_bytes;
+}
+
 static inline void
 shaper_update_bucket_tokens(struct tb_config *tb, uint64_t cur_cycles) {
     uint64_t elapsed_cycles;
@@ -372,13 +385,16 @@ ConfigureQerFlows(const UPDK_PDR *pdr, bool is_uplink) {
     bool has_gbr = qer->flags.guaranteedBitrate;
 
     uint32_t mbr = is_uplink ? qer->maximumBitrate.ul : qer->maximumBitrate.dl;
-    trtcm_params.pir = mbr * 1000 / 8;
+    trtcm_params.pir = (uint64_t)mbr * 1000 / 8;
+    trtcm_params.pbs = trtcm_bucket_depth(mbr);
 
     if (has_gbr) {
         uint32_t gbr = is_uplink ? qer->guaranteedBitrate.ul : qer->guaranteedBitrate.dl;
-        trtcm_params.cir = gbr * 1000 / 8;
+        trtcm_params.cir = (uint64_t)gbr * 1000 / 8;
+        trtcm_params.cbs = trtcm_bucket_depth(gbr);
     } else {
         trtcm_params.cir = 1;
+        trtcm_params.cbs = MIN_TOKEN_BUCKET_DEPTH;
     }
 
     int rtn = rte_meter_trtcm_profile_config(&app_flow_trtcm_profiles[trTCMidx],
@@ -411,9 +427,11 @@ ConfigureQerFlows(const UPDK_PDR *pdr, bool is_uplink) {
             UTLT_Info("Find GBR (DL: %lu) in QERs", qer->guaranteedBitrate.dl);
     }
 
-    UTLT_Info("TRTCM params: %d %d %d %d\n",
-              trtcm_params.cir, trtcm_params.pir,
-              trtcm_params.cbs, trtcm_params.pbs);
+    UTLT_Info("TRTCM params: %lu %lu %lu %lu\n",
+              (unsigned long)trtcm_params.cir,
+              (unsigned long)trtcm_params.pir,
+              (unsigned long)trtcm_params.cbs,
+              (unsigned long)trtcm_params.pbs);
 
     trTCMidx++;
 }

--- a/5gc/upf_u/upf_u_trtcm.c
+++ b/5gc/upf_u/upf_u_trtcm.c
@@ -21,9 +21,15 @@
 #include "utlt_debug.h"
 #include "upf_u_config.h"
 
+#include <stdint.h>
+#include <string.h>
+
+#include <rte_spinlock.h>
+
 #include "../classifiers/classifier_wrapper.h"
 
-#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+#define MIN_TOKEN_BUCKET_DEPTH 2048
+#define TOKEN_BUCKET_BURST_MS 10
 
 flow_entry_t iPFlows[APP_FLOWS_MAX];
 uint32_t iPFlowsLen = 0;
@@ -35,6 +41,8 @@ struct rte_meter_trtcm app_flows[APP_FLOWS_MAX];
 
 static struct ue_hash_entry ue_hash[MAX_UE];
 struct ue_tb ue_table[MAX_UE];
+static rte_spinlock_t ue_table_lock;
+static rte_spinlock_t ue_tb_locks[MAX_UE];
 
 /* trTCM */
 struct rte_meter_trtcm_params app_trtcm_params = {
@@ -50,13 +58,13 @@ trtcmConfigFlowTables(void) {
     int rtn;
     if (likely(app_flows[0].tc > 0))
         return 0;
-    
+
     // config trtcm profile
     rtn = rte_meter_trtcm_profile_config(&app_trtcm_profile,
 		&app_trtcm_params);
 	if (rtn)
 		return rtn;
-        
+
     // config flow meters with trtcm profiles
     for (i = 0; i < APP_FLOWS_MAX; i++){
         rtn = rte_meter_trtcm_config(&app_flows[i], &app_trtcm_profile);
@@ -77,12 +85,12 @@ trtcmColorHandle(uint32_t pkt_len, uint64_t time, uint8_t qfi, struct rte_meter_
         return -1;
     }
     if (unlikely(app_trtcm_profile.pir_period == 0)) {
-        UTLT_Info("flow pir_period set err");    
+        UTLT_Info("flow pir_period set err");
         return -1;
     }
-    out_color = (uint8_t) rte_meter_trtcm_color_blind_check(&app_flows[qfi], 
-        target_profile, 
-        time, 
+    out_color = (uint8_t) rte_meter_trtcm_color_blind_check(&app_flows[qfi],
+        target_profile,
+        time,
         pkt_len);
     return out_color;
 }
@@ -158,7 +166,7 @@ ftSearch(uint32_t subnet) {
             return iPFlows[index].flow_idx;
         }
         index = (index + 1) % APP_FLOWS_MAX;  // Linear Probing
-        
+
         if (index == original_index) {
             break;
         }
@@ -193,35 +201,128 @@ ftAddEntry(uint32_t subnet, int flow_idx) {
     return true;
 }
 
-void 
+void
 initUeTable() {
+    rte_spinlock_init(&ue_table_lock);
     for (int i = 0; i < MAX_UE; i++) {
+        uint64_t now = rte_get_tsc_cycles();
+
+        rte_spinlock_init(&ue_tb_locks[i]);
         ue_table[i].ue_ip = 0;
         ue_table[i].ue_ambr = 0;
         ue_table[i].ue_gbr = 0;
         ue_table[i].ue_mbr = 0;
 
-        ue_table[i].ue_nqos_tb_params.tb_rate = 0;
-        ue_table[i].ue_nqos_tb_params.tb_depth = 0;
-        ue_table[i].ue_nqos_tb_params.tb_tokens = 0;
-        ue_table[i].ue_nqos_tb_params.last_cycle = rte_get_tsc_cycles();
-        ue_table[i].ue_nqos_tb_params.cur_cycles = rte_get_tsc_cycles();
+        ue_table[i].ue_green_tb_params.tb_rate = 0;
+        ue_table[i].ue_green_tb_params.tb_depth = 0;
+        ue_table[i].ue_green_tb_params.tb_tokens = 0;
+        ue_table[i].ue_green_tb_params.last_cycle = now;
+        ue_table[i].ue_green_tb_params.cur_cycles = now;
 
-        ue_table[i].ue_qos_tb_params.tb_rate = 0;
-        ue_table[i].ue_qos_tb_params.tb_depth = 0;
-        ue_table[i].ue_qos_tb_params.tb_tokens = 0;
-        ue_table[i].ue_qos_tb_params.last_cycle = rte_get_tsc_cycles();
-        ue_table[i].ue_qos_tb_params.cur_cycles = rte_get_tsc_cycles();
+        ue_table[i].ue_excess_tb_params.tb_rate = 0;
+        ue_table[i].ue_excess_tb_params.tb_depth = 0;
+        ue_table[i].ue_excess_tb_params.tb_tokens = 0;
+        ue_table[i].ue_excess_tb_params.last_cycle = now;
+        ue_table[i].ue_excess_tb_params.cur_cycles = now;
+
+        ue_table[i].ue_yellow_cap_tb_params.tb_rate = 0;
+        ue_table[i].ue_yellow_cap_tb_params.tb_depth = 0;
+        ue_table[i].ue_yellow_cap_tb_params.tb_tokens = 0;
+        ue_table[i].ue_yellow_cap_tb_params.last_cycle = now;
+        ue_table[i].ue_yellow_cap_tb_params.cur_cycles = now;
     }
 }
 
 static inline int
 ueHashFunc(uint32_t ip) { return ip % MAX_UE; }
 
+static inline bool
+ueHashSlotInUse(int idx) {
+    return __atomic_load_n(&ue_hash[idx].in_use, __ATOMIC_ACQUIRE);
+}
+
+static inline void
+ueHashSetInUse(int idx, bool in_use) {
+    __atomic_store_n(&ue_hash[idx].in_use, in_use, __ATOMIC_RELEASE);
+}
+
+static inline uint64_t
+shaper_bucket_depth(uint32_t rate_kbps) {
+    uint64_t depth_bytes;
+
+    if (rate_kbps == 0)
+        return 0;
+
+    depth_bytes = ((uint64_t)rate_kbps * TOKEN_BUCKET_BURST_MS + 7) / 8;
+    return depth_bytes < MIN_TOKEN_BUCKET_DEPTH ?
+           MIN_TOKEN_BUCKET_DEPTH : depth_bytes;
+}
+
+static inline void
+shaper_update_bucket_tokens(struct tb_config *tb, uint64_t cur_cycles) {
+    uint64_t elapsed_cycles;
+    uint64_t tokens_produced;
+    __uint128_t produced;
+
+    if (tb->tb_rate == 0 || tb->tb_depth == 0) {
+        tb->tb_tokens = 0;
+        tb->last_cycle = cur_cycles;
+        return;
+    }
+
+    if (tb->tb_tokens >= tb->tb_depth) {
+        tb->tb_tokens = tb->tb_depth;
+        tb->last_cycle = cur_cycles;
+        return;
+    }
+
+    elapsed_cycles = cur_cycles - tb->last_cycle;
+    produced = ((__uint128_t)elapsed_cycles * tb->tb_rate * 125) /
+               rte_get_tsc_hz();
+    tokens_produced = produced > UINT64_MAX ? UINT64_MAX :
+                      (uint64_t)produced;
+    if (tokens_produced == 0)
+        return;
+
+    tb->tb_tokens += tokens_produced;
+    if (tb->tb_tokens > tb->tb_depth)
+        tb->tb_tokens = tb->tb_depth;
+    tb->last_cycle = cur_cycles;
+}
+
+static inline bool
+ueTokenIndexValid(int index) {
+    return index > -1 && index < MAX_UE && ue_table[index].ue_ip != 0;
+}
+
+static inline void
+updateTokenbyIndexLocked(int index, uint64_t cur_cycles) {
+    shaper_update_bucket_tokens(&ue_table[index].ue_green_tb_params,
+                                cur_cycles);
+    shaper_update_bucket_tokens(&ue_table[index].ue_excess_tb_params,
+                                cur_cycles);
+    shaper_update_bucket_tokens(&ue_table[index].ue_yellow_cap_tb_params,
+                                cur_cycles);
+}
+
+static inline void
+initBucket(struct tb_config *tb, uint32_t rate, uint64_t now) {
+    tb->tb_rate = rate;
+    tb->tb_depth = shaper_bucket_depth(rate);
+    tb->tb_tokens = tb->tb_depth;
+    tb->last_cycle = now;
+    tb->cur_cycles = now;
+}
+
+static inline bool
+bucketCanFitPacket(const struct tb_config *tb, uint32_t pkt_len) {
+    return tb->tb_depth > 0 && pkt_len <= tb->tb_depth;
+}
+
 void
 ueHashInit(void) {
     for (int i = 0; i < MAX_UE; i++)
-        ue_hash[i].in_use = false;
+        ueHashSetInUse(i, false);
 }
 
 void
@@ -293,7 +394,7 @@ static inline int
 ueHashSearch(uint32_t ue_ip) {
     int idx = ueHashFunc(ue_ip);
     int start = idx;
-    while (ue_hash[idx].in_use) {
+    while (ueHashSlotInUse(idx)) {
         if (ue_hash[idx].ue_ip == ue_ip)
             return ue_hash[idx].ue_idx;
         idx = (idx + 1) % MAX_UE;
@@ -306,78 +407,192 @@ static inline bool
 ueHashInsert(uint32_t ue_ip, int ue_idx) {
     if (ueHashSearch(ue_ip) >= 0) return false; /* already present */
     int idx = ueHashFunc(ue_ip);
-    while (ue_hash[idx].in_use)
+    int start = idx;
+
+    while (ueHashSlotInUse(idx)) {
         idx = (idx + 1) % MAX_UE;
+        if (idx == start)
+            return false;
+    }
     ue_hash[idx].ue_ip  = ue_ip;
     ue_hash[idx].ue_idx = ue_idx;
-    ue_hash[idx].in_use = true;
+    ueHashSetInUse(idx, true);
     return true;
 }
 
 /* Legacy wrapper — now O(1) via hash */
-int 
+int
 findIndexByUeIpAddress(uint32_t ue_ip) {
     return ueHashSearch(ue_ip);
 }
 
 int
 addEntrybyUeIp(uint32_t ue_ip, uint32_t ue_ambr, uint32_t ue_gbr, uint32_t ue_mbr) {
+    int added_idx = -1;
+    int existing_idx;
+
+    if (ue_ambr == 0) {
+        UTLT_Warning("Reject UE %u shaper config with zero AMBR", ue_ip);
+        return -1;
+    }
+
+    if (ue_gbr > ue_ambr)
+        ue_gbr = ue_ambr;
+    if (ue_mbr == 0 || ue_mbr > ue_ambr)
+        ue_mbr = ue_ambr;
+    if (ue_gbr > ue_mbr)
+        ue_gbr = ue_mbr;
+
+    rte_spinlock_lock(&ue_table_lock);
+    existing_idx = ueHashSearch(ue_ip);
+    if (existing_idx >= 0) {
+        rte_spinlock_unlock(&ue_table_lock);
+        return existing_idx;
+    }
+
     for (int i = 0; i < MAX_UE; i++) {
         if (ue_table[i].ue_ip == 0) { // find unused
-            ue_table[i].ue_ip = ue_ip;
+            uint64_t now = rte_get_tsc_cycles();
+            uint32_t green_rate = ue_gbr;
+            uint32_t excess_rate = ue_ambr > ue_gbr ?
+                                   ue_ambr - ue_gbr : 0;
+            uint32_t yellow_cap_rate = ue_mbr > ue_gbr ?
+                                       ue_mbr - ue_gbr : 0;
+
+            rte_spinlock_lock(&ue_tb_locks[i]);
             ue_table[i].ue_ambr = ue_ambr;
             ue_table[i].ue_gbr = ue_gbr;
+            ue_table[i].ue_mbr = ue_mbr;
 
-            uint32_t qos_rate = MIN((ue_gbr + (ue_ambr - ue_gbr) / 2), ue_mbr);
+            initBucket(&ue_table[i].ue_green_tb_params, green_rate, now);
+            initBucket(&ue_table[i].ue_excess_tb_params, excess_rate, now);
+            initBucket(&ue_table[i].ue_yellow_cap_tb_params,
+                       yellow_cap_rate, now);
 
-            ue_table[i].ue_qos_tb_params.tb_rate = qos_rate / 1000;
-            ue_table[i].ue_qos_tb_params.tb_depth = qos_rate;
-            ue_table[i].ue_qos_tb_params.tb_tokens = qos_rate;
-            ue_table[i].ue_qos_tb_params.last_cycle = rte_get_tsc_cycles();
-            ue_table[i].ue_qos_tb_params.cur_cycles = rte_get_tsc_cycles();
-            UTLT_Info("QoS Rate: %d", qos_rate);
+            UTLT_Info("Green GFBR Rate: %u", green_rate);
+            UTLT_Info("Shared Excess Rate: %u", excess_rate);
+            UTLT_Info("Yellow Cap Rate: %u", yellow_cap_rate);
 
-            uint32_t nqos_rate = ue_ambr - qos_rate;
-
-            ue_table[i].ue_nqos_tb_params.tb_rate = nqos_rate / 1000;
-            ue_table[i].ue_nqos_tb_params.tb_depth = nqos_rate;
-            ue_table[i].ue_nqos_tb_params.tb_tokens = nqos_rate;
-            ue_table[i].ue_nqos_tb_params.last_cycle = rte_get_tsc_cycles();
-            ue_table[i].ue_nqos_tb_params.cur_cycles = rte_get_tsc_cycles();
-            UTLT_Info("non QoS Rate: %d", nqos_rate);
-
-            ueHashInsert(ue_ip, i);
-            return i;  // Return the allocated index
+            ue_table[i].ue_ip = ue_ip;
+            rte_spinlock_unlock(&ue_tb_locks[i]);
+            if (ueHashInsert(ue_ip, i)) {
+                added_idx = i;
+            } else {
+                rte_spinlock_lock(&ue_tb_locks[i]);
+                memset(&ue_table[i], 0, sizeof(ue_table[i]));
+                rte_spinlock_unlock(&ue_tb_locks[i]);
+                added_idx = ueHashSearch(ue_ip);
+            }
+            break;
         }
     }
-    return -1;  // Table full
+    rte_spinlock_unlock(&ue_table_lock);
+    return added_idx;  // Return the allocated index, or -1 if table full
 }
 
-void 
+void
 updateTokenbyIndex(int index) {
-    if (index > -1) {
-        uint64_t cur_cycles;
-        uint64_t elapsed_cycles;
-        uint64_t tokens_produced;
+    uint64_t cur_cycles;
 
-        cur_cycles = rte_get_tsc_cycles();
-        elapsed_cycles = cur_cycles - ue_table[index].ue_nqos_tb_params.last_cycle;
-
-        tokens_produced = (elapsed_cycles * ue_table[index].ue_nqos_tb_params.tb_rate * 125000) / rte_get_tsc_hz();
-        ue_table[index].ue_nqos_tb_params.tb_tokens += tokens_produced;
-        if (ue_table[index].ue_nqos_tb_params.tb_tokens > ue_table[index].ue_nqos_tb_params.tb_depth)
-            ue_table[index].ue_nqos_tb_params.tb_tokens = ue_table[index].ue_nqos_tb_params.tb_depth;
-        ue_table[index].ue_nqos_tb_params.last_cycle = cur_cycles;
-
-        elapsed_cycles = cur_cycles - ue_table[index].ue_qos_tb_params.last_cycle;
-        tokens_produced = (elapsed_cycles * ue_table[index].ue_qos_tb_params.tb_rate * 125000) / rte_get_tsc_hz();
-        ue_table[index].ue_qos_tb_params.tb_tokens += tokens_produced;
-        if (ue_table[index].ue_qos_tb_params.tb_tokens > ue_table[index].ue_qos_tb_params.tb_depth)
-            ue_table[index].ue_qos_tb_params.tb_tokens = ue_table[index].ue_qos_tb_params.tb_depth;
-        ue_table[index].ue_qos_tb_params.last_cycle = cur_cycles;
-
+    if (unlikely(index < 0 || index >= MAX_UE)) {
+        UTLT_Error("UE IP not found in the table");
         return;
     }
+
+    rte_spinlock_lock(&ue_tb_locks[index]);
+    if (ueTokenIndexValid(index)) {
+        cur_cycles = rte_get_tsc_cycles();
+        updateTokenbyIndexLocked(index, cur_cycles);
+        rte_spinlock_unlock(&ue_tb_locks[index]);
+        return;
+    }
+    rte_spinlock_unlock(&ue_tb_locks[index]);
     UTLT_Error("UE IP not found in the table");
-    return;
+}
+
+bool
+ueBucketCanFitPacket(int index, enum ue_bucket_class bucket_class, uint32_t pkt_len) {
+    bool can_fit;
+
+    if (unlikely(index < 0 || index >= MAX_UE))
+        return false;
+
+    rte_spinlock_lock(&ue_tb_locks[index]);
+    if (unlikely(!ueTokenIndexValid(index))) {
+        rte_spinlock_unlock(&ue_tb_locks[index]);
+        return false;
+    }
+
+    switch (bucket_class) {
+    case UE_BUCKET_GREEN:
+        can_fit = bucketCanFitPacket(&ue_table[index].ue_green_tb_params,
+                                     pkt_len);
+        break;
+    case UE_BUCKET_YELLOW:
+        can_fit = bucketCanFitPacket(&ue_table[index].ue_excess_tb_params,
+                                     pkt_len) &&
+                  bucketCanFitPacket(&ue_table[index].ue_yellow_cap_tb_params,
+                                     pkt_len);
+        break;
+    case UE_BUCKET_NQOS:
+        can_fit = bucketCanFitPacket(&ue_table[index].ue_excess_tb_params,
+                                     pkt_len);
+        break;
+    default:
+        can_fit = false;
+        break;
+    }
+    rte_spinlock_unlock(&ue_tb_locks[index]);
+    return can_fit;
+}
+
+bool
+consumeUeBucketTokens(int index, enum ue_bucket_class bucket_class, uint32_t pkt_len) {
+    struct tb_config *green_tb;
+    struct tb_config *excess_tb;
+    struct tb_config *yellow_cap_tb;
+    bool consumed = false;
+
+    if (unlikely(index < 0 || index >= MAX_UE))
+        return false;
+
+    rte_spinlock_lock(&ue_tb_locks[index]);
+    if (unlikely(!ueTokenIndexValid(index))) {
+        rte_spinlock_unlock(&ue_tb_locks[index]);
+        return false;
+    }
+
+    updateTokenbyIndexLocked(index, rte_get_tsc_cycles());
+
+    green_tb = &ue_table[index].ue_green_tb_params;
+    excess_tb = &ue_table[index].ue_excess_tb_params;
+    yellow_cap_tb = &ue_table[index].ue_yellow_cap_tb_params;
+
+    switch (bucket_class) {
+    case UE_BUCKET_GREEN:
+        if (green_tb->tb_tokens >= pkt_len) {
+            green_tb->tb_tokens -= pkt_len;
+            consumed = true;
+        }
+        break;
+    case UE_BUCKET_YELLOW:
+        if (excess_tb->tb_tokens >= pkt_len &&
+            yellow_cap_tb->tb_tokens >= pkt_len) {
+            excess_tb->tb_tokens -= pkt_len;
+            yellow_cap_tb->tb_tokens -= pkt_len;
+            consumed = true;
+        }
+        break;
+    case UE_BUCKET_NQOS:
+        if (excess_tb->tb_tokens >= pkt_len) {
+            excess_tb->tb_tokens -= pkt_len;
+            consumed = true;
+        }
+        break;
+    default:
+        break;
+    }
+
+    rte_spinlock_unlock(&ue_tb_locks[index]);
+    return consumed;
 }

--- a/5gc/upf_u/upf_u_trtcm.c
+++ b/5gc/upf_u/upf_u_trtcm.c
@@ -351,6 +351,38 @@ bucketCanFitPacket(const struct tb_config *tb, uint32_t pkt_len) {
     return tb->tb_depth > 0 && pkt_len <= tb->tb_depth;
 }
 
+uint64_t
+ueShaperQueueLimitBytes(int index, bool is_qos, uint32_t delay_ms, uint64_t min_bytes) {
+    uint64_t rate_kbps = 0;
+    uint64_t limit_bytes;
+
+    if (unlikely(index < 0 || index >= MAX_UE))
+        return min_bytes;
+
+    rte_spinlock_lock(&ue_tb_locks[index]);
+    if (ueTokenIndexValid(index)) {
+        if (is_qos) {
+            if (ue_table[index].ue_mbr > 0)
+                rate_kbps = ue_table[index].ue_mbr;
+            else if (ue_table[index].ue_gbr > 0)
+                rate_kbps = ue_table[index].ue_gbr;
+            else
+                rate_kbps = ue_table[index].ue_ambr;
+        } else {
+            rate_kbps = ue_table[index].ue_excess_tb_params.tb_rate;
+            if (rate_kbps == 0)
+                rate_kbps = ue_table[index].ue_ambr;
+        }
+    }
+    rte_spinlock_unlock(&ue_tb_locks[index]);
+
+    if (rate_kbps == 0 || delay_ms == 0)
+        return min_bytes;
+
+    limit_bytes = (rate_kbps * (uint64_t)delay_ms + 7) / 8;
+    return limit_bytes > min_bytes ? limit_bytes : min_bytes;
+}
+
 void
 ueHashInit(void) {
     for (int i = 0; i < MAX_UE; i++)

--- a/5gc/upf_u/upf_u_trtcm.c
+++ b/5gc/upf_u/upf_u_trtcm.c
@@ -29,7 +29,7 @@
 #include "../classifiers/classifier_wrapper.h"
 
 #define MIN_TOKEN_BUCKET_DEPTH 2048
-#define TOKEN_BUCKET_BURST_MS 10
+#define TOKEN_BUCKET_BURST_MS 100
 #define TRTCM_BURST_MS 100
 
 flow_entry_t iPFlows[APP_FLOWS_MAX];

--- a/5gc/upf_u/upf_u_trtcm.c
+++ b/5gc/upf_u/upf_u_trtcm.c
@@ -293,7 +293,10 @@ trtcm_bucket_depth(uint32_t rate_kbps) {
 static inline void
 shaper_update_bucket_tokens(struct tb_config *tb, uint64_t cur_cycles) {
     uint64_t elapsed_cycles;
+    uint64_t cycles_used;
+    uint64_t tsc_hz;
     uint64_t tokens_produced;
+    __uint128_t byte_rate;
     __uint128_t produced;
 
     if (tb->tb_rate == 0 || tb->tb_depth == 0) {
@@ -309,17 +312,26 @@ shaper_update_bucket_tokens(struct tb_config *tb, uint64_t cur_cycles) {
     }
 
     elapsed_cycles = cur_cycles - tb->last_cycle;
-    produced = ((__uint128_t)elapsed_cycles * tb->tb_rate * 125) /
-               rte_get_tsc_hz();
+    tsc_hz = rte_get_tsc_hz();
+    byte_rate = (__uint128_t)tb->tb_rate * 125;
+    produced = ((__uint128_t)elapsed_cycles * byte_rate) / tsc_hz;
     tokens_produced = produced > UINT64_MAX ? UINT64_MAX :
                       (uint64_t)produced;
     if (tokens_produced == 0)
         return;
 
-    tb->tb_tokens += tokens_produced;
-    if (tb->tb_tokens > tb->tb_depth)
+    if (tokens_produced >= tb->tb_depth - tb->tb_tokens) {
         tb->tb_tokens = tb->tb_depth;
-    tb->last_cycle = cur_cycles;
+        tb->last_cycle = cur_cycles;
+        return;
+    }
+
+    tb->tb_tokens += tokens_produced;
+    cycles_used = (uint64_t)(((__uint128_t)tokens_produced * tsc_hz) /
+                             byte_rate);
+    if (cycles_used == 0)
+        cycles_used = 1;
+    tb->last_cycle += cycles_used;
 }
 
 static inline bool

--- a/5gc/upf_u/upf_u_trtcm.h
+++ b/5gc/upf_u/upf_u_trtcm.h
@@ -76,7 +76,7 @@ extern uint32_t iPFlowsLen;
 extern uint32_t trTCMidx;
 
 extern struct rte_meter_trtcm_profile app_trtcm_profile;
-extern struct rte_meter_trtcm_profile app_flow_trtcm_profile;
+extern struct rte_meter_trtcm_profile app_flow_trtcm_profiles[APP_FLOWS_MAX];
 extern struct rte_meter_trtcm app_flows[APP_FLOWS_MAX];
 
 extern struct rte_meter_trtcm_params app_trtcm_params;
@@ -87,7 +87,10 @@ int
 trtcmConfigFlowTables(void);
 
 int
-trtcmColorHandle(uint32_t pkt_len, uint64_t time, uint8_t qfi, struct rte_meter_trtcm_profile *target_profile);
+trtcmColorHandle(uint32_t pkt_len, uint64_t time, int flow_idx, struct rte_meter_trtcm_profile *target_profile);
+
+struct rte_meter_trtcm_profile *
+trtcmProfileForFlow(int flow_idx);
 
 int
 trtcmPolicer(struct onvm_pkt_meta *meta, int color_result);

--- a/5gc/upf_u/upf_u_trtcm.h
+++ b/5gc/upf_u/upf_u_trtcm.h
@@ -46,7 +46,7 @@ struct ue_hash_entry {
 
 /* Token Bucket */
 struct tb_config {
-    uint64_t tb_rate;    // rate at which tokens are generated (in MBps)
+    uint64_t tb_rate;    // token generation rate in Kbps
     uint64_t tb_depth;   // depth of the token bucket (in bytes)
     uint64_t tb_tokens;  // number of the tokens in the bucket at any given time (in bytes)
     uint64_t last_cycle;
@@ -54,13 +54,21 @@ struct tb_config {
     uint16_t used;
 };
 
+enum ue_bucket_class {
+    UE_BUCKET_GREEN = 0,
+    UE_BUCKET_YELLOW,
+    UE_BUCKET_NQOS,
+    UE_BUCKET_COUNT
+};
+
 struct ue_tb {
     uint32_t ue_ip;
     uint32_t ue_ambr;
     uint32_t ue_gbr;
     uint32_t ue_mbr;
-    struct tb_config ue_nqos_tb_params;
-    struct tb_config ue_qos_tb_params;
+    struct tb_config ue_green_tb_params;
+    struct tb_config ue_excess_tb_params;
+    struct tb_config ue_yellow_cap_tb_params;
 };
 
 extern flow_entry_t iPFlows[APP_FLOWS_MAX];
@@ -84,7 +92,7 @@ trtcmColorHandle(uint32_t pkt_len, uint64_t time, uint8_t qfi, struct rte_meter_
 int
 trtcmPolicer(struct onvm_pkt_meta *meta, int color_result);
 
-void 
+void
 initUeTable();
 
 void
@@ -96,11 +104,17 @@ ConfigureQerFlows(const UPDK_PDR *pdr, bool is_uplink);
 int
 ftSearch(uint32_t subnet);
 
-int 
+int
 findIndexByUeIpAddress(uint32_t ue_ip);
 
-void 
+void
 updateTokenbyIndex(int index);
+
+bool
+ueBucketCanFitPacket(int index, enum ue_bucket_class bucket_class, uint32_t pkt_len);
+
+bool
+consumeUeBucketTokens(int index, enum ue_bucket_class bucket_class, uint32_t pkt_len);
 
 int
 addEntrybyUeIp(uint32_t ue_ip, uint32_t ue_ambr, uint32_t ue_gbr, uint32_t ue_mbr);

--- a/5gc/upf_u/upf_u_trtcm.h
+++ b/5gc/upf_u/upf_u_trtcm.h
@@ -119,6 +119,9 @@ ueBucketCanFitPacket(int index, enum ue_bucket_class bucket_class, uint32_t pkt_
 bool
 consumeUeBucketTokens(int index, enum ue_bucket_class bucket_class, uint32_t pkt_len);
 
+uint64_t
+ueShaperQueueLimitBytes(int index, bool is_qos, uint32_t delay_ms, uint64_t min_bytes);
+
 int
 addEntrybyUeIp(uint32_t ue_ip, uint32_t ue_ambr, uint32_t ue_gbr, uint32_t ue_mbr);
 

--- a/onvm/utlt/upf_events.h
+++ b/onvm/utlt/upf_events.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include <stdint.h>
+
+#include <rte_malloc.h>
+
+#include "onvm_nflib.h"
+#include "utlt_event.h"
+
 // UPF-U service id = 1
 #ifndef UPF_U_SERVICE_ID
 #define UPF_U_SERVICE_ID  1 
@@ -17,4 +24,15 @@ enum {
         EVT_CLS_GC_ACK = 0x4202,
 };
 
+static inline int
+UpfSendEvt1(uint16_t dest_sid, uint32_t type, uintptr_t a0) {
+        Event *e = (Event *)rte_calloc("upf_evt", 1, sizeof(*e), 0);
+        if (!e) return -1;
+        e->type = (uintptr_t)type;
+        e->argc = 1;
+        e->arg0 = a0;
+        int rc = onvm_nflib_send_msg_to_nf(dest_sid, e);
+        if (rc < 0) rte_free(e);
+        return rc;
+}
 


### PR DESCRIPTION
## Summary

This PR replaces the old UPF-U downlink token behavior with a non-blocking GFBR-first shared-excess shaper.

The old path could block the worker while waiting for token-bucket credit, derive the wrong UE rate profile from only the matched PDR, and under-produce tokens during frequent shaper polling. This PR changes the downlink FORW path so packets that pass trTCM but temporarily lack UE token credit are held in bounded per-UE/per-flow queues and drained as tokens refill.

At a high level, the shaper now enforces one UE AMBR budget:

- QoS green traffic uses the guaranteed/GFBR bucket first.
- QoS excess/yellow traffic uses shared excess capacity up to the QoS MBR.
- Default/non-QoS traffic uses the remaining shared excess capacity.
- Sustained overload is handled by bounded queueing and policy drops, not worker busy-waiting or stale packet buildup.

## Commit Map

| Commit | Change | Why it matters |
| --- | --- | --- |
| `702dc97` `upf: introduce GFBR-first shared-excess shaper` | Introduces the non-blocking per-UE/per-flow shaper, active-UE scanning, shaper entry pool, queue/drain path, and explicit shaper counters. | Replaces blocking/drop-on-token-shortage behavior with a drainable shaper that can preserve packets while enforcing UE buckets. |
| `d6a5a00` `upf: isolate trTCM profiles per QoS flow` | Stores a trTCM profile per flow-table entry instead of reusing one mutable profile. | Prevents later QER/SDF configuration from changing the meter used by earlier flows. |
| `66e8a4c` `upf: keep Non-GBR QoS out of green buckets` | Tracks whether a trTCM flow has GBR and remaps Non-GBR green results to yellow/excess treatment. | Keeps Non-GBR QoS from consuming or failing against a zero-depth guaranteed bucket. |
| `b5bdfd2` `upf: aggregate UE GBR rates across QERs` | Sums GBR and MBR across GBR-bearing QERs instead of using last-QER-wins values. | Makes the UE guaranteed reservation match all GBR QoS flows under the UE. |
| `e226483` `upf: account DL QoS bytes by packet protocol` | Computes DL metered length from IPv4 total length and actual UDP/TCP headers. | Avoids UDP-only length assumptions and keeps trTCM/token accounting closer to configured rates. |
| `89dfbb3` `upf: use shared UPF event sender` | Moves the UPF event send helper toward shared use. | Keeps UPF-C and UPF-U control messages on the same helper path. |
| `31d8c43` `upf: derive shaper AMBR from session QERs` | Collects AMBR/GBR/MBR from the owning session's QER list first, with matched-PDR QERs as fallback. | Fixes the bug where a QoS PDR's `5 Mbps` MBR was mistaken for the whole UE AMBR, even though session AMBR was `10 Mbps`. |
| `2603b60` `upf: derive trTCM burst sizes from QER rates` | Sizes trTCM CBS/PBS from QER rates instead of small static defaults. | Reduces false red coloring for normal packet bursts near configured QoS rates. |
| `80ed485` `upf: tune QoS shaper buffering for MBR tests` | Increases drain, class burst, queue, and token-bucket burst tolerance. | Gives the shaper enough buffering headroom for UDP MBR validation. |
| `9756aed` `Limit UPF-U shaper queue latency` | Adds rate-derived per-flow queue byte limits, oldest-packet trimming, explicit inline drain budget, and cleanup for enqueue failure paths. | Keeps sustained overload from turning into a long stale queue while preserving real-time rate limiting behavior. |
| `bf27566` `Preserve fractional shaper token refill` | Advances `last_cycle` only by cycles actually consumed by whole-byte token credit. | Fixes the observed lower-throughput plateau caused by repeatedly discarding fractional refill time. |
| `1157348` `upf: address Copilot shaper review findings` | Restores `UpfSendEvt1()` as a shared helper, passes the UE's owning session into AMBR derivation, drops malformed DL length accounting early, and guards the shaper callback context. | Addresses Copilot's latest real issues: possible build failure, unreachable session-QER rate path, inconsistent zero-length/malformed accounting, and a possible null callback dereference. |

## Rate Model

The main validation setup uses one UE session with two concurrent downlink UDP flows:

- UE IP: `10.60.0.1`
- QoS DN source: `192.168.3.2`, port `5201`
- Default DN source: `192.168.3.3`, port `5202`
- UE AMBR and DNN AMBR: `10 Mbps`
- QoS flow rule: `192.168.3.2/32`
- QoS GBR: `2 Mbps`
- QoS MBR: `5 Mbps`
- Expected default/non-QoS cap: `8 Mbps` (`AMBR - GBR`)

The expected shaper registration for that setup is:

```text
Add UE IP: 10.60.0.1, AMBR: 10000 GBR: 2000, MBR: 5000
Green GFBR Rate: 2000
Shared Excess Rate: 8000
Yellow Cap Rate: 3000
```

Before `31d8c43`, the same setup could register as `AMBR=5000, GBR=2000, MBR=5000` because the matched QoS PDR carried only the QoS QER. That shrank the whole UE from `10 Mbps` AMBR to the QoS flow's `5 Mbps` MBR. The session-QER derivation fixes that by using the full session QER list when available.

## Validation

### 10 Mbps Profile

Detailed logs are in `iperf log/validation/20260628-203903/`.

- UE AMBR: `10 Mbps`
- QoS GBR: `2 Mbps`
- QoS MBR/cap: `5 Mbps`
- Default/non-QoS cap: `8 Mbps`
- iperf duration: `30s`, omit: `3s`

Single-flow sweep:

| Flow | Offered rate | Receiver rate | Loss |
| --- | ---: | ---: | ---: |
| QoS | `3 Mbps` | `3.00 Mbits/sec` | `0%` |
| QoS | `4 Mbps` | `4.00 Mbits/sec` | `0%` |
| QoS | `5 Mbps` | `5.00 Mbits/sec` | `0%` |
| QoS | `6 Mbps` | `5.00 Mbits/sec` | `18%` |
| QoS | `8 Mbps` | `5.00 Mbits/sec` | `41%` |
| QoS | `10 Mbps` | `5.00 Mbits/sec` | `55%` |
| Default/non-QoS | `6 Mbps` | `6.00 Mbits/sec` | `0%` |
| Default/non-QoS | `8 Mbps` | `8.00 Mbits/sec` | `0%` |
| Default/non-QoS | `10 Mbps` | `8.00 Mbits/sec` | `22%` |
| Default/non-QoS | `12 Mbps` | `8.00 Mbits/sec` | `36%` |

Completed concurrent two-flow results:

| QoS offered | Default offered | QoS receiver | Default receiver | Combined receiver |
| ---: | ---: | ---: | ---: | ---: |
| `3 Mbps` | `3 Mbps` | `3.00 Mbits/sec` | `3.00 Mbits/sec` | `6.00 Mbits/sec` |
| `3 Mbps` | `7 Mbps` | `3.00 Mbits/sec` | `7.00 Mbits/sec` | `10.00 Mbits/sec` |
| `5 Mbps` | `5 Mbps` | `5.00 Mbits/sec` | `5.00 Mbits/sec` | `10.00 Mbits/sec` |
| `6 Mbps` | `6 Mbps` | `5.00 Mbits/sec` | `5.00 Mbits/sec` | `10.00 Mbits/sec` |
| `8 Mbps` | `8 Mbps` | `5.00 Mbits/sec` | `5.00 Mbits/sec` | `10.00 Mbits/sec` |
| `5 Mbps` | `8 Mbps` | `5.00 Mbits/sec` | `5.00 Mbits/sec` | `10.00 Mbits/sec` |
| `8 Mbps` | `5 Mbps` | `5.00 Mbits/sec` | `5.00 Mbits/sec` | `10.00 Mbits/sec` |

This profile shows the intended small-scale behavior directly: QoS is clean through its `5 Mbps` MBR, default/non-QoS is clean through its `8 Mbps` cap, and concurrent overload stays near the `10 Mbps` UE AMBR. The old failure mode was not just loss under overload. It was a lower plateau: QoS overload could stabilize around `4.34 Mbps`, and default/non-QoS overload could stabilize around `5.5 Mbps`. `bf27566` is the key token-refill fix for that plateau.

### 500 Mbps Profile

A larger run in `iperf log/validation/20260629-051846/` uses the same topology but scales the rates:

- UE AMBR: `500 Mbps`
- QoS GBR: `100 Mbps`
- QoS MBR/cap: `250 Mbps`
- Default/non-QoS cap: `400 Mbps`
- iperf duration: `30s`, omit: `3s`

Single-flow sweep:

| Flow | Offered rate | Receiver rate | Loss |
| --- | ---: | ---: | ---: |
| QoS | `150 Mbps` | `150 Mbits/sec` | `0%` |
| QoS | `200 Mbps` | `200 Mbits/sec` | `0.015%` |
| QoS | `250 Mbps` | `250 Mbits/sec` | `0.062%` |
| QoS | `300 Mbps` | `250 Mbits/sec` | `18%` |
| QoS | `400 Mbps` | `250 Mbits/sec` | `41%` |
| QoS | `500 Mbps` | `250 Mbits/sec` | `55%` |
| Default/non-QoS | `300 Mbps` | `300 Mbits/sec` | `0.042%` |
| Default/non-QoS | `400 Mbps` | `400 Mbits/sec` | `0.06%` |
| Default/non-QoS | `500 Mbps` | `399 Mbits/sec` | `22%` |
| Default/non-QoS | `600 Mbps` | `400 Mbits/sec` | `36%` |

Completed concurrent two-flow results:

| QoS offered | Default offered | QoS receiver | Default receiver | Combined receiver |
| ---: | ---: | ---: | ---: | ---: |
| `150 Mbps` | `150 Mbps` | `150 Mbits/sec` | `150 Mbits/sec` | `300 Mbits/sec` |
| `150 Mbps` | `350 Mbps` | `150 Mbits/sec` | `348 Mbits/sec` | `498 Mbits/sec` |
| `250 Mbps` | `250 Mbps` | `249 Mbits/sec` | `249 Mbits/sec` | `498 Mbits/sec` |
| `300 Mbps` | `300 Mbps` | `247 Mbits/sec` | `248 Mbits/sec` | `495 Mbits/sec` |
| `400 Mbps` | `400 Mbps` | `246 Mbits/sec` | `248 Mbits/sec` | `494 Mbits/sec` |

This larger run shows the same behavior at higher rates: single-flow overload holds near the configured cap, and two-flow overload keeps the combined receiver rate near the `500 Mbps` UE AMBR. The later `250 Mbps + 400 Mbps` pair in that folder was interrupted and produced a `291.92s` summary with `0.00 bits/sec` receiver output, so it is not counted as a valid pass/fail result.

I did not push beyond this throughput profile because, at higher offered rates, the gNB sometimes crashed. Those runs would mix UPF shaper behavior with gNB stability limits, so they are not useful as shaper validation evidence.

## Pass/Fail Criteria

Pass:

- The UPF log shows the expected UE shaper profile for the configured AMBR/GBR/MBR.
- QoS overload traffic stays near its configured MBR.
- Default/non-QoS overload traffic stays near its configured default cap.
- Concurrent overload sums near UE AMBR.
- No mempool-empty drops dominate the result.

Fail:

- The UE profile is wrong, for example `AMBR: 5000` in the `10 Mbps` setup.
- QoS/default overload traffic stabilizes at an unexplained lower plateau.
- Concurrent two-flow totals fall far below UE AMBR without an offered-rate or configured-cap reason.
- Mempool-empty or invalid drops dominate, because then the experiment is measuring resource exhaustion instead of shaper behavior.

## Review Focus

Please focus review on:

- mbuf ownership while packets are held in the shaper entry pool
- per-UE/per-flow queue bounds under sustained overload
- GFBR-first fairness between QoS green, QoS excess/yellow, and default/non-QoS active lists
- session-level QER rate derivation for AMBR/GBR/MBR
- token-bucket refill precision and queue-drain behavior under UDP bursts
