### PR TITLE
Feat/NAT implementation

### DIFF
--- a/5gc/upf_u/config/upf_u.yaml
+++ b/5gc/upf_u/config/upf_u.yaml
@@ -3,12 +3,10 @@ info:
   description: L25GC+ UPF-U Configuration
 
 configuration:
-  log_level: "warning"  # trace, debug, info, warning, error, fatal, panic
+  log_level: "trace"  # trace, debug, info, warning, error, fatal, panic
   dataplane:
     upf_n3_ip: "192.168.1.2"        # N3 interface IP address on the Core Network node
     upf_n6_ip: "192.168.1.3"        # N6 interface IP address on the Core Network node
-    an_peer_n3_ip: "192.168.1.1"    # N3 interface IP address on the UE/RAN node
-    dn_peer_n6_ip: "192.168.1.4"    # N6 interface IP address on the DN node
 
     ports:
       n3_port: 0                     # NIC port used for N3 interface
@@ -17,6 +15,8 @@ configuration:
   # NAT configuration (optional)
   nat:
     enable: false # true/false or 1/0
+    an_peer_n3_ip: "192.168.1.1"    # N3 interface IP address on the UE/RAN node
+    dn_peer_n6_ip: "192.168.1.4"    # N6 interface IP address on the DN node
     public_ip: "192.168.1.3"
     port_min: 10000
     port_max: 60000

--- a/5gc/upf_u/config/upf_u.yaml
+++ b/5gc/upf_u/config/upf_u.yaml
@@ -16,7 +16,7 @@ configuration:
 
   # NAT configuration (optional)
   nat:
-    enable: false
+    enable: false # true/false or 1/0
     public_ip: "192.168.1.3"
     port_min: 10000
     port_max: 60000

--- a/5gc/upf_u/config/upf_u.yaml
+++ b/5gc/upf_u/config/upf_u.yaml
@@ -3,7 +3,7 @@ info:
   description: L25GC+ UPF-U Configuration
 
 configuration:
-  log_level: "trace"  # trace, debug, info, warning, error, fatal, panic
+  log_level: "warning"  # trace, debug, info, warning, error, fatal, panic
   dataplane:
     upf_n3_ip: "192.168.1.2"        # N3 interface IP address on the Core Network node
     upf_n6_ip: "192.168.1.3"        # N6 interface IP address on the Core Network node

--- a/5gc/upf_u/config/upf_u.yaml
+++ b/5gc/upf_u/config/upf_u.yaml
@@ -7,7 +7,16 @@ configuration:
   dataplane:
     upf_n3_ip: "192.168.1.2"        # N3 interface IP address on the Core Network node
     upf_n6_ip: "192.168.1.3"        # N6 interface IP address on the Core Network node
+    an_peer_n3_ip: "192.168.1.1"    # N3 interface IP address on the UE/RAN node
+    dn_peer_n6_ip: "192.168.1.4"    # N6 interface IP address on the DN node
 
     ports:
       n3_port: 0                     # NIC port used for N3 interface
       n6_port: 1                     # NIC port used for N6 interface
+
+  # NAT configuration (optional)
+  nat:
+    enable: false
+    public_ip: "192.168.1.3"
+    port_min: 10000
+    port_max: 60000

--- a/5gc/upf_u/meson.build
+++ b/5gc/upf_u/meson.build
@@ -4,6 +4,7 @@ sources = files(
     'upf_u_arp.c',
     'upf_u_icmp.c',
     'upf_u_trtcm.c',
+    'upf_u_nat.c',
     'upf_u_helper.c'
 )
 

--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -932,9 +932,7 @@ main(int argc, char *argv[]) {
 
     /* NAT module init (only if enabled in config) */
     if (g_nat_enabled) {
-        if (nat_init() < 0) {
-            rte_exit(EXIT_FAILURE, "failed to init NAT module\n");
-        }
+        nat_init();
     }
 
     onvm_nflib_run(nf_local_ctx);

--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/queue.h>
-#include <time.h>
 #include <unistd.h>
 #include <stdbool.h>
 
@@ -55,6 +54,7 @@
 #include "upf_u_config.h"
 #include "upf_u_arp.h"
 #include "upf_u_icmp.h"
+#include "upf_u_nat.h"
 #include "upf_u_trtcm.h"
 
 #define NF_TAG "upf_u"
@@ -128,7 +128,6 @@ UpfClsMaybeFlipAndAck(void) {
 
     (void)UpfSendEvt1(UPF_C_SERVICE_ID, EVT_CLS_GC_ACK, (uintptr_t)v2);
 }
-
 
 /* static inline const UPDK_PDR *
 UpfLookupPdr(const ps_packet_t *key) {
@@ -545,7 +544,26 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
         pdr = GetPdrByTeid(pkt, &gtp_info);
 
     } else {
-        // UTLT_Info("It is downlink, dst is %s\n", convertToIpAddressString(iph->dst_addr));
+        UTLT_Trace("DL ingress: port=%u dst=%s proto=%u",
+                   pkt->port,
+                   convertToIpAddressString(iph->dst_addr),
+                   iph->next_proto_id);
+
+        if (pkt->port == g_n6_port && g_nat_enabled) {
+            int dnat_rc = nat_apply_dnat(iph);
+            UTLT_Trace("DL NAT: rc=%d post-dnat dst=%s proto=%u",
+                       dnat_rc,
+                       convertToIpAddressString(iph->dst_addr),
+                       iph->next_proto_id);
+            if (dnat_rc < 0 && iph->dst_addr == g_nat_public_ip_be) {
+                UTLT_Warning("NAT DNAT miss for public packet %s:%u",
+                             convertToIpAddressString(iph->dst_addr),
+                             nat_dst_port(iph));
+                meta->action = ONVM_NF_ACTION_DROP;
+                return 0;
+            }
+        }
+
         pdr = GetPdrByUeIpAddress(pkt, rte_cpu_to_be_32(iph->dst_addr));
         is_dl = true;
     }
@@ -625,14 +643,9 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
                 Encap(pkt, far, pdr->qer);
         }
 
-        /* Get the gNB N3 IP address */
-        uint32_t gnb_n3_ip_be =
-            far->forwardingParameters.outerHeaderCreation.ipv4.s_addr;
-        UTLT_Trace("gNB N3 IP: %s\n", convertToIpAddressString(gnb_n3_ip_be));
-
         // Regardless of BUFF vs FORW, we need to attach L2 (or ARP) header
         // before sending to N3 port.
-        if (attach_l2_or_arp(pkt, g_n3_port, g_n3_ip_be, gnb_n3_ip_be,
+        if (attach_l2_or_arp(pkt, g_n3_port, g_n3_ip_be, g_an_peer_n3_ip_be,
                             nf_local_ctx->nf) < 0) {
             meta->action = ONVM_NF_ACTION_DROP;   /* or buffer */
             return 0;
@@ -752,6 +765,24 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
             return 0;
         }
 
+        if (g_nat_enabled && meta->action == ONVM_NF_ACTION_OUT) {
+            char src_buf[16];
+            char dst_buf[16];
+            UTLT_Trace("UL ingress: port=%u src=%s dst=%s proto=%u",
+                       pkt->port,
+                       ipv4_to_buf(inner_iph->src_addr, src_buf),
+                       ipv4_to_buf(inner_iph->dst_addr, dst_buf),
+                       inner_iph->next_proto_id);
+            if (nat_apply_snat(inner_iph) < 0) {
+                meta->action = ONVM_NF_ACTION_DROP;
+                return 0;
+            }
+            UTLT_Trace("UL NAT: post-snat src=%s dst=%s proto=%u",
+                       ipv4_to_buf(inner_iph->src_addr, src_buf),
+                       ipv4_to_buf(inner_iph->dst_addr, dst_buf),
+                       inner_iph->next_proto_id);
+        }
+
         if (meta->action == ONVM_NF_ACTION_OUT) {
             /* Get the DN server IP address */
             uint32_t dn_server_ip_be = inner_iph->dst_addr;
@@ -784,7 +815,9 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
             }
 
             /* Attach L2 (or ARP) header for the N6-bound packet */
-            if (attach_l2_or_arp(pkt, g_n6_port, g_n6_ip_be, dn_server_ip_be,
+            uint32_t n6_next_hop_ip_be = g_dn_peer_n6_ip_be ? g_dn_peer_n6_ip_be : dn_server_ip_be;
+            UTLT_Trace("N6 next hop IP: %s", convertToIpAddressString(n6_next_hop_ip_be));
+            if (attach_l2_or_arp(pkt, g_n6_port, g_n6_ip_be, n6_next_hop_ip_be,
                                 nf_local_ctx->nf) < 0) {
                 meta->action = ONVM_NF_ACTION_DROP;
                 return 0;
@@ -895,6 +928,13 @@ main(int argc, char *argv[]) {
     /* ARP module init */
     if (upf_arp_init() < 0) {
         rte_exit(EXIT_FAILURE, "failed to init ARP module\n");
+    }
+
+    /* NAT module init (only if enabled in config) */
+    if (g_nat_enabled) {
+        if (nat_init() < 0) {
+            rte_exit(EXIT_FAILURE, "failed to init NAT module\n");
+        }
     }
 
     onvm_nflib_run(nf_local_ctx);

--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -643,9 +643,14 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
                 Encap(pkt, far, pdr->qer);
         }
 
+        uint32_t gnb_n3_ip_be = g_nat_enabled 
+            ? g_an_peer_n3_ip_be
+            : far->forwardingParameters.outerHeaderCreation.ipv4.s_addr;
+        UTLT_Trace("gNB N3 IP: %s\n", convertToIpAddressString(gnb_n3_ip_be));
+
         // Regardless of BUFF vs FORW, we need to attach L2 (or ARP) header
         // before sending to N3 port.
-        if (attach_l2_or_arp(pkt, g_n3_port, g_n3_ip_be, g_an_peer_n3_ip_be,
+        if (attach_l2_or_arp(pkt, g_n3_port, g_n3_ip_be, gnb_n3_ip_be,
                             nf_local_ctx->nf) < 0) {
             meta->action = ONVM_NF_ACTION_DROP;   /* or buffer */
             return 0;
@@ -815,9 +820,9 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
             }
 
             /* Attach L2 (or ARP) header for the N6-bound packet */
-            uint32_t n6_next_hop_ip_be = g_dn_peer_n6_ip_be ? g_dn_peer_n6_ip_be : dn_server_ip_be;
-            UTLT_Trace("N6 next hop IP: %s", convertToIpAddressString(n6_next_hop_ip_be));
-            if (attach_l2_or_arp(pkt, g_n6_port, g_n6_ip_be, n6_next_hop_ip_be,
+            dn_server_ip_be = g_nat_enabled ? g_dn_peer_n6_ip_be : dn_server_ip_be;
+
+            if (attach_l2_or_arp(pkt, g_n6_port, g_n6_ip_be, dn_server_ip_be,
                                 nf_local_ctx->nf) < 0) {
                 meta->action = ONVM_NF_ACTION_DROP;
                 return 0;

--- a/5gc/upf_u/upf_u_config.c
+++ b/5gc/upf_u/upf_u_config.c
@@ -254,7 +254,7 @@ do_parse(yaml_document_t *doc) {
         yaml_node_t *enabled = map_get(doc, nat, "enable");
         const char *enable_str = scalar_str(enabled);
         if (enable_str) {
-            if (strcmp(enable_str, "true") == 0) {
+            if (strcmp(enable_str, "true") == 0 || strcmp(enable_str, "1") == 0) {
                 g_nat_enabled = 1;
             } else {
                 g_nat_enabled = 0;

--- a/5gc/upf_u/upf_u_config.c
+++ b/5gc/upf_u/upf_u_config.c
@@ -33,7 +33,14 @@ uint16_t g_n6_port   = 0;
 uint16_t g_sgi_port    = 0;
 
 uint32_t g_n3_ip_be = 0;
-uint32_t g_n6_ip_be   = 0;
+uint32_t g_n6_ip_be = 0;
+uint32_t g_an_peer_n3_ip_be = 0;
+uint32_t g_dn_peer_n6_ip_be = 0;
+
+uint8_t g_nat_enabled = 0;
+uint32_t g_nat_public_ip_be = 0;
+uint16_t g_nat_port_min = 10000;
+uint16_t g_nat_port_max = 60000;
 
 char g_log_level[16] = "warning";
 
@@ -170,6 +177,48 @@ do_parse(yaml_document_t *doc) {
             return -1;
         }
     }
+    
+    // an_peer_n3_ip
+    {
+        yaml_node_t *n = map_get(doc, dp, "an_peer_n3_ip");
+        if (!n || n->type != YAML_SCALAR_NODE) {
+            fprintf(stderr, "[UPF-U][CONFIG] missing an_peer_n3_ip\n");
+            return -1;
+        }
+        const unsigned char *p = n->data.scalar.value;
+        size_t len = n->data.scalar.length;
+
+        char buf[64];
+        if (len >= sizeof(buf)) len = sizeof(buf) - 1;
+        memcpy(buf, p, len);
+        buf[len] = '\0';
+
+        if (parse_ipv4_address(buf, &g_an_peer_n3_ip_be) != 0) {
+            fprintf(stderr, "[UPF-U][CONFIG] invalid an_peer_n3_ip\n");
+            return -1;
+        }
+    }
+
+    // dn_peer_n6_ip
+    {
+        yaml_node_t *n = map_get(doc, dp, "dn_peer_n6_ip");
+        if (!n || n->type != YAML_SCALAR_NODE) {
+            fprintf(stderr, "[UPF-U][CONFIG] missing dn_peer_n6_ip\n");
+            return -1;
+        }
+        const unsigned char *p = n->data.scalar.value;
+        size_t len = n->data.scalar.length;
+
+        char buf[64];
+        if (len >= sizeof(buf)) len = sizeof(buf) - 1;
+        memcpy(buf, p, len);
+        buf[len] = '\0';
+
+        if (parse_ipv4_address(buf, &g_dn_peer_n6_ip_be) != 0) {
+            fprintf(stderr, "[UPF-U][CONFIG] invalid dn_peer_n6_ip\n");
+            return -1;
+        }
+    }
 
     // ports
     {
@@ -196,6 +245,68 @@ do_parse(yaml_document_t *doc) {
             if (v < 0 || v > 255) { fprintf(stderr, "[UPF-U][CONFIG] bad ports.n6_port\n"); return -1; }
             g_n6_port = (uint16_t)v;
             g_sgi_port  = (uint16_t)v;
+        }
+    }
+
+    yaml_node_t *nat = map_get(doc, cfg, "nat");
+
+    if (nat && nat->type == YAML_MAPPING_NODE) {
+        yaml_node_t *enabled = map_get(doc, nat, "enable");
+        const char *enable_str = scalar_str(enabled);
+        if (enable_str) {
+            if (strcmp(enable_str, "true") == 0) {
+                g_nat_enabled = 1;
+            } else {
+                g_nat_enabled = 0;
+            }
+        }
+
+        {
+            yaml_node_t *n = map_get(doc, nat, "public_ip");
+            const char *s = scalar_str(n);
+            if (s && *s) {
+                if (parse_ipv4_address(s, &g_nat_public_ip_be) != 0) {
+                    fprintf(stderr, "[UPF-U][CONFIG] invalid nat.public_ip\n");
+                    return -1;
+                }
+            }
+        }
+
+        {
+            yaml_node_t *n = map_get(doc, nat, "port_min");
+            const char *s = scalar_str(n);
+            if (s && *s) {
+                int v = atoi(s);
+                if (v < 1 || v > 65535) {
+                    fprintf(stderr, "[UPF-U][CONFIG] bad nat.port_min\n");
+                    return -1;
+                }
+                g_nat_port_min = (uint16_t)v;
+            }
+        }
+
+        {
+            yaml_node_t *n = map_get(doc, nat, "port_max");
+            const char *s = scalar_str(n);
+            if (s && *s) {
+                int v = atoi(s);
+                if (v < 1 || v > 65535) {
+                    fprintf(stderr, "[UPF-U][CONFIG] bad nat.port_max\n");
+                    return -1;
+                }
+                g_nat_port_max = (uint16_t)v;
+            }
+        }
+    }
+
+    if (g_nat_enabled) {
+        if (!g_nat_public_ip_be) {
+            fprintf(stderr, "[UPF-U][CONFIG] nat.enable requires nat.public_ip\n");
+            return -1;
+        }
+        if (g_nat_port_min > g_nat_port_max) {
+            fprintf(stderr, "[UPF-U][CONFIG] nat.port_min must be <= nat.port_max\n");
+            return -1;
         }
     }
 

--- a/5gc/upf_u/upf_u_config.c
+++ b/5gc/upf_u/upf_u_config.c
@@ -34,10 +34,10 @@ uint16_t g_sgi_port    = 0;
 
 uint32_t g_n3_ip_be = 0;
 uint32_t g_n6_ip_be = 0;
-uint32_t g_an_peer_n3_ip_be = 0;
-uint32_t g_dn_peer_n6_ip_be = 0;
 
 uint8_t g_nat_enabled = 0;
+uint32_t g_an_peer_n3_ip_be = 0;
+uint32_t g_dn_peer_n6_ip_be = 0;
 uint32_t g_nat_public_ip_be = 0;
 uint16_t g_nat_port_min = 10000;
 uint16_t g_nat_port_max = 60000;
@@ -177,48 +177,6 @@ do_parse(yaml_document_t *doc) {
             return -1;
         }
     }
-    
-    // an_peer_n3_ip
-    {
-        yaml_node_t *n = map_get(doc, dp, "an_peer_n3_ip");
-        if (!n || n->type != YAML_SCALAR_NODE) {
-            fprintf(stderr, "[UPF-U][CONFIG] missing an_peer_n3_ip\n");
-            return -1;
-        }
-        const unsigned char *p = n->data.scalar.value;
-        size_t len = n->data.scalar.length;
-
-        char buf[64];
-        if (len >= sizeof(buf)) len = sizeof(buf) - 1;
-        memcpy(buf, p, len);
-        buf[len] = '\0';
-
-        if (parse_ipv4_address(buf, &g_an_peer_n3_ip_be) != 0) {
-            fprintf(stderr, "[UPF-U][CONFIG] invalid an_peer_n3_ip\n");
-            return -1;
-        }
-    }
-
-    // dn_peer_n6_ip
-    {
-        yaml_node_t *n = map_get(doc, dp, "dn_peer_n6_ip");
-        if (!n || n->type != YAML_SCALAR_NODE) {
-            fprintf(stderr, "[UPF-U][CONFIG] missing dn_peer_n6_ip\n");
-            return -1;
-        }
-        const unsigned char *p = n->data.scalar.value;
-        size_t len = n->data.scalar.length;
-
-        char buf[64];
-        if (len >= sizeof(buf)) len = sizeof(buf) - 1;
-        memcpy(buf, p, len);
-        buf[len] = '\0';
-
-        if (parse_ipv4_address(buf, &g_dn_peer_n6_ip_be) != 0) {
-            fprintf(stderr, "[UPF-U][CONFIG] invalid dn_peer_n6_ip\n");
-            return -1;
-        }
-    }
 
     // ports
     {
@@ -261,52 +219,93 @@ do_parse(yaml_document_t *doc) {
             }
         }
 
-        {
-            yaml_node_t *n = map_get(doc, nat, "public_ip");
-            const char *s = scalar_str(n);
-            if (s && *s) {
-                if (parse_ipv4_address(s, &g_nat_public_ip_be) != 0) {
-                    fprintf(stderr, "[UPF-U][CONFIG] invalid nat.public_ip\n");
+        if (g_nat_enabled) {
+            // an_peer_n3_ip
+            {
+                yaml_node_t *n = map_get(doc, nat, "an_peer_n3_ip");
+                if (!n || n->type != YAML_SCALAR_NODE) {
+                    fprintf(stderr, "[UPF-U][CONFIG] missing an_peer_n3_ip\n");
+                    return -1;
+                }
+                const unsigned char *p = n->data.scalar.value;
+                size_t len = n->data.scalar.length;
+
+                char buf[64];
+                if (len >= sizeof(buf)) len = sizeof(buf) - 1;
+                memcpy(buf, p, len);
+                buf[len] = '\0';
+
+                if (parse_ipv4_address(buf, &g_an_peer_n3_ip_be) != 0) {
+                    fprintf(stderr, "[UPF-U][CONFIG] invalid an_peer_n3_ip\n");
                     return -1;
                 }
             }
-        }
 
-        {
-            yaml_node_t *n = map_get(doc, nat, "port_min");
-            const char *s = scalar_str(n);
-            if (s && *s) {
-                int v = atoi(s);
-                if (v < 1 || v > 65535) {
-                    fprintf(stderr, "[UPF-U][CONFIG] bad nat.port_min\n");
+            // dn_peer_n6_ip
+            {
+                yaml_node_t *n = map_get(doc, nat, "dn_peer_n6_ip");
+                if (!n || n->type != YAML_SCALAR_NODE) {
+                    fprintf(stderr, "[UPF-U][CONFIG] missing dn_peer_n6_ip\n");
                     return -1;
                 }
-                g_nat_port_min = (uint16_t)v;
-            }
-        }
+                const unsigned char *p = n->data.scalar.value;
+                size_t len = n->data.scalar.length;
 
-        {
-            yaml_node_t *n = map_get(doc, nat, "port_max");
-            const char *s = scalar_str(n);
-            if (s && *s) {
-                int v = atoi(s);
-                if (v < 1 || v > 65535) {
-                    fprintf(stderr, "[UPF-U][CONFIG] bad nat.port_max\n");
+                char buf[64];
+                if (len >= sizeof(buf)) len = sizeof(buf) - 1;
+                memcpy(buf, p, len);
+                buf[len] = '\0';
+
+                if (parse_ipv4_address(buf, &g_dn_peer_n6_ip_be) != 0) {
+                    fprintf(stderr, "[UPF-U][CONFIG] invalid dn_peer_n6_ip\n");
                     return -1;
                 }
-                g_nat_port_max = (uint16_t)v;
             }
-        }
-    }
 
-    if (g_nat_enabled) {
-        if (!g_nat_public_ip_be) {
-            fprintf(stderr, "[UPF-U][CONFIG] nat.enable requires nat.public_ip\n");
-            return -1;
-        }
-        if (g_nat_port_min > g_nat_port_max) {
-            fprintf(stderr, "[UPF-U][CONFIG] nat.port_min must be <= nat.port_max\n");
-            return -1;
+            {
+                yaml_node_t *n = map_get(doc, nat, "public_ip");
+                const char *s = scalar_str(n);
+                if (s && *s) {
+                    if (parse_ipv4_address(s, &g_nat_public_ip_be) != 0) {
+                        fprintf(stderr, "[UPF-U][CONFIG] invalid nat.public_ip\n");
+                        return -1;
+                    }
+                }
+            }
+
+            {
+                yaml_node_t *n = map_get(doc, nat, "port_min");
+                const char *s = scalar_str(n);
+                if (s && *s) {
+                    int v = atoi(s);
+                    if (v < 1 || v > 65535) {
+                        fprintf(stderr, "[UPF-U][CONFIG] bad nat.port_min\n");
+                        return -1;
+                    }
+                    g_nat_port_min = (uint16_t)v;
+                }
+            }
+
+            {
+                yaml_node_t *n = map_get(doc, nat, "port_max");
+                const char *s = scalar_str(n);
+                if (s && *s) {
+                    int v = atoi(s);
+                    if (v < 1 || v > 65535) {
+                        fprintf(stderr, "[UPF-U][CONFIG] bad nat.port_max\n");
+                        return -1;
+                    }
+                    g_nat_port_max = (uint16_t)v;
+                }
+            }
+            if (!g_nat_public_ip_be) {
+                fprintf(stderr, "[UPF-U][CONFIG] nat.enable requires nat.public_ip\n");
+                return -1;
+            }
+            if (g_nat_port_min > g_nat_port_max) {
+                fprintf(stderr, "[UPF-U][CONFIG] nat.port_min must be <= nat.port_max\n");
+                return -1;
+            }
         }
     }
 

--- a/5gc/upf_u/upf_u_config.h
+++ b/5gc/upf_u/upf_u_config.h
@@ -25,14 +25,14 @@
 
 extern uint32_t g_n3_ip_be;     // UPF local IP on the access-facing port
 extern uint32_t g_n6_ip_be;     // UPF local IP on the core/SGi-facing port
-extern uint32_t g_an_peer_n3_ip_be;  // Next-hop IP of the AN/gNB peer
-extern uint32_t g_dn_peer_n6_ip_be;  // Next-hop IP of the DN/upstream router peer
 
 extern uint16_t  g_n3_port;      // UPF-U DPDK port connected to the access side (AN/gNB)
 extern uint16_t  g_n6_port;      // UPF-U DPDK port connected to the core side (SGi)
 extern uint16_t  g_sgi_port;     // UPF-U DPDK port connected to the SGi side
 
 extern uint8_t  g_nat_enabled;       // Enable dynamic IPv4 NAT on N6
+extern uint32_t g_an_peer_n3_ip_be;  // Next-hop IP of the AN/gNB peer
+extern uint32_t g_dn_peer_n6_ip_be;  // Next-hop IP of the DN/upstream router peer
 extern uint32_t g_nat_public_ip_be;  // Public IPv4 used for SNAT/DNAT on N6
 extern uint16_t g_nat_port_min;      // Inclusive start of dynamic NAT port pool
 extern uint16_t g_nat_port_max;      // Inclusive end of dynamic NAT port pool

--- a/5gc/upf_u/upf_u_config.h
+++ b/5gc/upf_u/upf_u_config.h
@@ -25,10 +25,17 @@
 
 extern uint32_t g_n3_ip_be;     // UPF local IP on the access-facing port
 extern uint32_t g_n6_ip_be;     // UPF local IP on the core/SGi-facing port
+extern uint32_t g_an_peer_n3_ip_be;  // Next-hop IP of the AN/gNB peer
+extern uint32_t g_dn_peer_n6_ip_be;  // Next-hop IP of the DN/upstream router peer
 
 extern uint16_t  g_n3_port;      // UPF-U DPDK port connected to the access side (AN/gNB)
 extern uint16_t  g_n6_port;      // UPF-U DPDK port connected to the core side (SGi)
 extern uint16_t  g_sgi_port;     // UPF-U DPDK port connected to the SGi side
+
+extern uint8_t  g_nat_enabled;       // Enable dynamic IPv4 NAT on N6
+extern uint32_t g_nat_public_ip_be;  // Public IPv4 used for SNAT/DNAT on N6
+extern uint16_t g_nat_port_min;      // Inclusive start of dynamic NAT port pool
+extern uint16_t g_nat_port_max;      // Inclusive end of dynamic NAT port pool
 
 extern struct rte_ether_addr g_cn_ue_eth;  // Ethernet address for access-facing side of UPF (used when sending to UE)
 extern struct rte_ether_addr g_cn_dn_eth;  // Ethernet address for core-facing side of UPF (used when sending to DN)

--- a/5gc/upf_u/upf_u_icmp.c
+++ b/5gc/upf_u/upf_u_icmp.c
@@ -90,6 +90,12 @@ handle_local_icmp_echo(struct rte_mbuf *pkt,
     if (!upf_is_local_ipv4(iph->dst_addr))
         return 0;
 
+    /* NAT public-IP traffic on N6 must stay in the UPF datapath (DNAT),
+     * not be consumed by local ICMP handling. */
+    if (g_nat_enabled && pkt->port == g_n6_port &&
+        iph->dst_addr == g_nat_public_ip_be)
+        return 0;
+
     ip_hdr_len = (uint16_t)((iph->version_ihl & 0x0f) * 4);
     if (unlikely(ip_hdr_len < sizeof(struct rte_ipv4_hdr))) {
         meta->action = ONVM_NF_ACTION_DROP;

--- a/5gc/upf_u/upf_u_nat.c
+++ b/5gc/upf_u/upf_u_nat.c
@@ -1,0 +1,494 @@
+/*
+# Copyright 2026 University of California, Riverside and National Yang Ming Chiao Tung University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+*/
+
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+
+#include <rte_common.h>
+#include <rte_icmp.h>
+#include <rte_ip.h>
+#include <rte_tcp.h>
+#include <rte_udp.h>
+
+#include "utlt_debug.h"
+
+#include "upf_u_config.h"
+#include "upf_u_helper.h"
+#include "upf_u_nat.h"
+
+#define NAT_TABLE_MAX 1024
+#define NAT_HASH_BUCKETS 2048
+#define NAT_IDLE_TIMEOUT_SEC 300
+
+struct nat_binding {
+    uint8_t  in_use;
+    uint8_t  proto;
+    uint16_t ue_port;
+    uint16_t remote_port;
+    uint16_t public_port;
+    uint32_t ue_ip;
+    uint32_t remote_ip;
+    time_t   last_seen;
+    int32_t  hash_next;
+};
+
+static struct nat_binding g_nat_bindings[NAT_TABLE_MAX];
+static int32_t g_nat_tuple_buckets[NAT_HASH_BUCKETS];
+static int32_t g_nat_port_map[UINT16_MAX + 1];
+static uint16_t g_nat_free_stack[NAT_TABLE_MAX];
+static uint16_t g_nat_free_top = 0;
+static uint16_t g_nat_next_port = 0;
+
+void
+nat_init(void)
+{
+    memset(g_nat_bindings, 0, sizeof(g_nat_bindings));
+    for (size_t i = 0; i < RTE_DIM(g_nat_tuple_buckets); i++) {
+        g_nat_tuple_buckets[i] = -1;
+    }
+    for (size_t i = 0; i < RTE_DIM(g_nat_port_map); i++) {
+        g_nat_port_map[i] = -1;
+    }
+    g_nat_free_top = NAT_TABLE_MAX;
+    for (size_t i = 0; i < NAT_TABLE_MAX; i++) {
+        g_nat_bindings[i].hash_next = -1;
+        g_nat_free_stack[i] = (uint16_t)(NAT_TABLE_MAX - 1 - i);
+    }
+    g_nat_next_port = g_nat_port_min;
+}
+
+static inline int
+nat_supported_proto(uint8_t proto)
+{
+    return proto == IPPROTO_UDP || proto == IPPROTO_TCP || proto == IPPROTO_ICMP;
+}
+
+static inline void *
+nat_l4_hdr(const struct rte_ipv4_hdr *iph)
+{
+    uint16_t ihl = (uint16_t)(iph->version_ihl & 0x0F) * 4;
+    return ((uint8_t *)iph) + ihl;
+}
+
+static inline uint16_t
+nat_src_port(const struct rte_ipv4_hdr *iph)
+{
+    if (iph->next_proto_id == IPPROTO_UDP) {
+        const struct rte_udp_hdr *udp = (const struct rte_udp_hdr *)nat_l4_hdr(iph);
+        return rte_be_to_cpu_16(udp->src_port);
+    }
+    if (iph->next_proto_id == IPPROTO_TCP) {
+        const struct rte_tcp_hdr *tcp = (const struct rte_tcp_hdr *)nat_l4_hdr(iph);
+        return rte_be_to_cpu_16(tcp->src_port);
+    }
+    if (iph->next_proto_id == IPPROTO_ICMP) {
+        const struct rte_icmp_hdr *icmp = (const struct rte_icmp_hdr *)nat_l4_hdr(iph);
+        return rte_be_to_cpu_16(icmp->icmp_ident);
+    }
+    return 0;
+}
+
+uint16_t
+nat_dst_port(const struct rte_ipv4_hdr *iph)
+{
+    if (iph->next_proto_id == IPPROTO_UDP) {
+        const struct rte_udp_hdr *udp = (const struct rte_udp_hdr *)nat_l4_hdr(iph);
+        return rte_be_to_cpu_16(udp->dst_port);
+    }
+    if (iph->next_proto_id == IPPROTO_TCP) {
+        const struct rte_tcp_hdr *tcp = (const struct rte_tcp_hdr *)nat_l4_hdr(iph);
+        return rte_be_to_cpu_16(tcp->dst_port);
+    }
+    if (iph->next_proto_id == IPPROTO_ICMP) {
+        const struct rte_icmp_hdr *icmp = (const struct rte_icmp_hdr *)nat_l4_hdr(iph);
+        return rte_be_to_cpu_16(icmp->icmp_ident);
+    }
+    return 0;
+}
+
+static inline void
+nat_set_src_port(struct rte_ipv4_hdr *iph, uint16_t port)
+{
+    if (iph->next_proto_id == IPPROTO_UDP) {
+        struct rte_udp_hdr *udp = (struct rte_udp_hdr *)nat_l4_hdr(iph);
+        udp->src_port = rte_cpu_to_be_16(port);
+        return;
+    }
+    if (iph->next_proto_id == IPPROTO_TCP) {
+        struct rte_tcp_hdr *tcp = (struct rte_tcp_hdr *)nat_l4_hdr(iph);
+        tcp->src_port = rte_cpu_to_be_16(port);
+        return;
+    }
+    if (iph->next_proto_id == IPPROTO_ICMP) {
+        struct rte_icmp_hdr *icmp = (struct rte_icmp_hdr *)nat_l4_hdr(iph);
+        icmp->icmp_ident = rte_cpu_to_be_16(port);
+    }
+}
+
+static inline void
+nat_set_dst_port(struct rte_ipv4_hdr *iph, uint16_t port)
+{
+    if (iph->next_proto_id == IPPROTO_UDP) {
+        struct rte_udp_hdr *udp = (struct rte_udp_hdr *)nat_l4_hdr(iph);
+        udp->dst_port = rte_cpu_to_be_16(port);
+        return;
+    }
+    if (iph->next_proto_id == IPPROTO_TCP) {
+        struct rte_tcp_hdr *tcp = (struct rte_tcp_hdr *)nat_l4_hdr(iph);
+        tcp->dst_port = rte_cpu_to_be_16(port);
+        return;
+    }
+    if (iph->next_proto_id == IPPROTO_ICMP) {
+        struct rte_icmp_hdr *icmp = (struct rte_icmp_hdr *)nat_l4_hdr(iph);
+        icmp->icmp_ident = rte_cpu_to_be_16(port);
+    }
+}
+
+static uint16_t
+nat_raw_checksum(const void *buf, size_t len)
+{
+    const uint16_t *data = (const uint16_t *)buf;
+    uint32_t sum = 0;
+
+    while (len > 1) {
+        sum += *data++;
+        len -= 2;
+    }
+
+    if (len == 1) {
+        sum += *((const uint8_t *)data);
+    }
+
+    while (sum >> 16) {
+        sum = (sum & 0xFFFFu) + (sum >> 16);
+    }
+
+    return (uint16_t)(~sum);
+}
+
+static inline void
+nat_recompute_checksums(struct rte_ipv4_hdr *iph)
+{
+    iph->hdr_checksum = 0;
+    iph->hdr_checksum = rte_ipv4_cksum(iph);
+
+    if (iph->next_proto_id == IPPROTO_UDP) {
+        struct rte_udp_hdr *udp = (struct rte_udp_hdr *)nat_l4_hdr(iph);
+        if (udp->dgram_cksum != 0) {
+            udp->dgram_cksum = 0;
+            udp->dgram_cksum = rte_ipv4_udptcp_cksum(iph, udp);
+        }
+        return;
+    }
+
+    if (iph->next_proto_id == IPPROTO_TCP) {
+        struct rte_tcp_hdr *tcp = (struct rte_tcp_hdr *)nat_l4_hdr(iph);
+        tcp->cksum = 0;
+        tcp->cksum = rte_ipv4_udptcp_cksum(iph, tcp);
+        return;
+    }
+
+    if (iph->next_proto_id == IPPROTO_ICMP) {
+        struct rte_icmp_hdr *icmp = (struct rte_icmp_hdr *)nat_l4_hdr(iph);
+        uint16_t total_len = rte_be_to_cpu_16(iph->total_length);
+        uint16_t ihl = (uint16_t)(iph->version_ihl & 0x0F) * 4;
+        uint16_t icmp_len = total_len > ihl ? (uint16_t)(total_len - ihl) : 0;
+        icmp->icmp_cksum = 0;
+        icmp->icmp_cksum = nat_raw_checksum(icmp, icmp_len);
+    }
+}
+
+static inline int
+nat_binding_matches(const struct nat_binding *b, uint8_t proto, uint32_t ue_ip,
+                    uint16_t ue_port, uint32_t remote_ip, uint16_t remote_port)
+{
+    return b->in_use &&
+           b->proto == proto &&
+           b->ue_ip == ue_ip &&
+           b->ue_port == ue_port &&
+           b->remote_ip == remote_ip &&
+           b->remote_port == remote_port;
+}
+
+static inline uint32_t
+nat_mix32(uint32_t x)
+{
+    x ^= x >> 16;
+    x *= 0x7feb352dU;
+    x ^= x >> 15;
+    x *= 0x846ca68bU;
+    x ^= x >> 16;
+    return x;
+}
+
+static inline uint32_t
+nat_tuple_hash(uint8_t proto, uint32_t ue_ip, uint16_t ue_port,
+               uint32_t remote_ip, uint16_t remote_port)
+{
+    uint32_t h = ue_ip;
+    h ^= nat_mix32(remote_ip);
+    h ^= ((uint32_t)ue_port << 16) | remote_port;
+    h ^= (uint32_t)proto * 0x9e3779b1U;
+    return nat_mix32(h) & (NAT_HASH_BUCKETS - 1);
+}
+
+static void
+nat_unlink_from_tuple_hash(int idx)
+{
+    struct nat_binding *b = &g_nat_bindings[idx];
+    uint32_t bucket = nat_tuple_hash(b->proto, b->ue_ip, b->ue_port,
+                                     b->remote_ip, b->remote_port);
+    int32_t *cur = &g_nat_tuple_buckets[bucket];
+
+    while (*cur >= 0) {
+        if (*cur == idx) {
+            *cur = g_nat_bindings[idx].hash_next;
+            return;
+        }
+        cur = &g_nat_bindings[*cur].hash_next;
+    }
+}
+
+static void
+nat_release_binding(int idx)
+{
+    if (idx < 0 || idx >= NAT_TABLE_MAX || !g_nat_bindings[idx].in_use) {
+        return;
+    }
+
+    nat_unlink_from_tuple_hash(idx);
+    g_nat_port_map[g_nat_bindings[idx].public_port] = -1;
+    memset(&g_nat_bindings[idx], 0, sizeof(g_nat_bindings[idx]));
+    g_nat_bindings[idx].hash_next = -1;
+
+    if (g_nat_free_top < NAT_TABLE_MAX) {
+        g_nat_free_stack[g_nat_free_top++] = (uint16_t)idx;
+    }
+}
+
+static inline int
+nat_binding_expired(const struct nat_binding *b, time_t now)
+{
+    return (now - b->last_seen) > NAT_IDLE_TIMEOUT_SEC;
+}
+
+static int
+nat_find_binding(uint8_t proto, uint32_t ue_ip, uint16_t ue_port,
+                 uint32_t remote_ip, uint16_t remote_port, time_t now)
+{
+    uint32_t bucket = nat_tuple_hash(proto, ue_ip, ue_port, remote_ip, remote_port);
+    int32_t idx = g_nat_tuple_buckets[bucket];
+
+    while (idx >= 0) {
+        struct nat_binding *b = &g_nat_bindings[idx];
+        int32_t next = b->hash_next;
+
+        if (nat_binding_expired(b, now)) {
+            nat_release_binding(idx);
+            idx = next;
+            continue;
+        }
+
+        if (nat_binding_matches(b, proto, ue_ip, ue_port, remote_ip, remote_port)) {
+            b->last_seen = now;
+            return idx;
+        }
+
+        idx = next;
+    }
+    return -1;
+}
+
+static int
+nat_alloc_binding_slot(time_t now)
+{
+    if (g_nat_free_top > 0) {
+        return g_nat_free_stack[--g_nat_free_top];
+    }
+
+    for (int i = 0; i < NAT_TABLE_MAX; i++) {
+        if (g_nat_bindings[i].in_use && nat_binding_expired(&g_nat_bindings[i], now)) {
+            nat_release_binding(i);
+            return g_nat_free_stack[--g_nat_free_top];
+        }
+    }
+
+    return -1;
+}
+
+static int
+nat_alloc_port(time_t now)
+{
+    if (!g_nat_enabled || g_nat_port_min > g_nat_port_max) {
+        return -1;
+    }
+
+    uint32_t range = (uint32_t)g_nat_port_max - (uint32_t)g_nat_port_min + 1;
+    if (range == 0) {
+        return -1;
+    }
+
+    if (g_nat_next_port < g_nat_port_min || g_nat_next_port > g_nat_port_max) {
+        g_nat_next_port = g_nat_port_min;
+    }
+
+    for (uint32_t i = 0; i < range; i++) {
+        uint16_t candidate = (uint16_t)(g_nat_port_min + ((g_nat_next_port - g_nat_port_min + i) % range));
+        int32_t idx = g_nat_port_map[candidate];
+        if (idx >= 0 && idx < NAT_TABLE_MAX &&
+            g_nat_bindings[idx].in_use &&
+            nat_binding_expired(&g_nat_bindings[idx], now)) {
+            nat_release_binding(idx);
+            idx = -1;
+        }
+        if (idx < 0 || idx >= NAT_TABLE_MAX || !g_nat_bindings[idx].in_use) {
+            g_nat_next_port = (candidate == g_nat_port_max) ? g_nat_port_min : (uint16_t)(candidate + 1);
+            return candidate;
+        }
+    }
+    return -1;
+}
+
+static int
+nat_create_binding(uint8_t proto, uint32_t ue_ip, uint16_t ue_port,
+                   uint32_t remote_ip, uint16_t remote_port, time_t now)
+{
+    int free_idx = nat_alloc_binding_slot(now);
+
+    if (free_idx < 0) {
+        return -1;
+    }
+
+    int public_port = nat_alloc_port(now);
+    if (public_port < 0) {
+        g_nat_free_stack[g_nat_free_top++] = (uint16_t)free_idx;
+        return -1;
+    }
+
+    struct nat_binding *b = &g_nat_bindings[free_idx];
+    b->in_use = 1;
+    b->proto = proto;
+    b->ue_ip = ue_ip;
+    b->ue_port = ue_port;
+    b->remote_ip = remote_ip;
+    b->remote_port = remote_port;
+    b->public_port = (uint16_t)public_port;
+    b->last_seen = now;
+    uint32_t bucket = nat_tuple_hash(proto, ue_ip, ue_port, remote_ip, remote_port);
+    b->hash_next = g_nat_tuple_buckets[bucket];
+    g_nat_tuple_buckets[bucket] = free_idx;
+    g_nat_port_map[b->public_port] = free_idx;
+
+    char ue_buf[16];
+    char pub_buf[16];
+    char remote_buf[16];
+    UTLT_Info("NAT create: UE %s:%u <-> public %s:%u remote %s:%u proto=%u",
+              ipv4_to_buf(ue_ip, ue_buf), ue_port,
+              ipv4_to_buf(g_nat_public_ip_be, pub_buf), b->public_port,
+              ipv4_to_buf(remote_ip, remote_buf), remote_port, proto);
+    return free_idx;
+}
+
+static int
+nat_get_or_create_binding(uint8_t proto, uint32_t ue_ip, uint16_t ue_port,
+                          uint32_t remote_ip, uint16_t remote_port)
+{
+    time_t now = time(NULL);
+    int idx = nat_find_binding(proto, ue_ip, ue_port, remote_ip, remote_port, now);
+    if (idx >= 0) {
+        return idx;
+    }
+    return nat_create_binding(proto, ue_ip, ue_port, remote_ip, remote_port, now);
+}
+
+static int
+nat_find_binding_by_public(uint8_t proto, uint16_t public_port)
+{
+    int32_t idx = g_nat_port_map[public_port];
+    if (idx < 0 || idx >= NAT_TABLE_MAX) {
+        return -1;
+    }
+
+    struct nat_binding *b = &g_nat_bindings[idx];
+    if (!b->in_use || b->proto != proto) {
+        return -1;
+    }
+
+    time_t now = time(NULL);
+    if (nat_binding_expired(b, now)) {
+        nat_release_binding(idx);
+        return -1;
+    }
+
+    b->last_seen = now;
+    return idx;
+}
+
+int
+nat_apply_snat(struct rte_ipv4_hdr *iph)
+{
+    if (!g_nat_enabled || !iph || !nat_supported_proto(iph->next_proto_id)) {
+        return 0;
+    }
+
+    uint32_t ue_ip = iph->src_addr;
+    uint32_t remote_ip = iph->dst_addr;
+    uint16_t ue_port = nat_src_port(iph);
+    uint16_t remote_port = nat_dst_port(iph);
+
+    int idx = nat_get_or_create_binding(iph->next_proto_id, ue_ip, ue_port, remote_ip, remote_port);
+    if (idx < 0) {
+        UTLT_Error("NAT SNAT: unable to allocate binding");
+        return -1;
+    }
+
+    struct nat_binding *b = &g_nat_bindings[idx];
+    iph->src_addr = g_nat_public_ip_be;
+    nat_set_src_port(iph, b->public_port);
+    nat_recompute_checksums(iph);
+    return 0;
+}
+
+int
+nat_apply_dnat(struct rte_ipv4_hdr *iph)
+{
+    if (!g_nat_enabled || !iph) {
+        return 0;
+    }
+
+    if (iph->dst_addr != g_nat_public_ip_be) {
+        return 0;
+    }
+
+    if (!nat_supported_proto(iph->next_proto_id)) {
+        return -1;
+    }
+
+    uint16_t public_port = nat_dst_port(iph);
+    int idx = nat_find_binding_by_public(iph->next_proto_id, public_port);
+    if (idx < 0) {
+        return -1;
+    }
+
+    struct nat_binding *b = &g_nat_bindings[idx];
+    iph->dst_addr = b->ue_ip;
+    nat_set_dst_port(iph, b->ue_port);
+    nat_recompute_checksums(iph);
+    return 1;
+}

--- a/5gc/upf_u/upf_u_nat.c
+++ b/5gc/upf_u/upf_u_nat.c
@@ -21,6 +21,7 @@
 #include <time.h>
 
 #include <rte_common.h>
+#include <rte_cksum.h>
 #include <rte_icmp.h>
 #include <rte_ip.h>
 #include <rte_tcp.h>
@@ -163,17 +164,7 @@ nat_set_dst_port(struct rte_ipv4_hdr *iph, uint16_t port)
 static uint16_t
 nat_raw_checksum(const void *buf, size_t len)
 {
-    const uint16_t *data = (const uint16_t *)buf;
-    uint32_t sum = 0;
-
-    while (len > 1) {
-        sum += *data++;
-        len -= 2;
-    }
-
-    if (len == 1) {
-        sum += *((const uint8_t *)data);
-    }
+    uint32_t sum = rte_raw_cksum(buf, len);
 
     while (sum >> 16) {
         sum = (sum & 0xFFFFu) + (sum >> 16);

--- a/5gc/upf_u/upf_u_nat.h
+++ b/5gc/upf_u/upf_u_nat.h
@@ -1,0 +1,38 @@
+/*
+# Copyright 2026 University of California, Riverside and National Yang Ming Chiao Tung University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+*/
+
+#ifndef UPF_U_NAT_H
+#define UPF_U_NAT_H
+
+#include <stdint.h>
+
+#include <rte_ip.h>
+
+void
+nat_init(void);
+
+uint16_t
+nat_dst_port(const struct rte_ipv4_hdr *iph);
+
+int
+nat_apply_snat(struct rte_ipv4_hdr *iph);
+
+int
+nat_apply_dnat(struct rte_ipv4_hdr *iph);
+
+#endif


### PR DESCRIPTION
This pull request introduces support for dynamic IPv4 NAT (Network Address Translation) in the UPF-U component, along with enhancements to next-hop configuration for both access and data network interfaces. The changes include configuration file updates, new global variables, NAT initialization and logic in the packet handling path, and the addition of a new NAT header file.

**NAT support and configuration:**

* Added NAT configuration options (`nat.enable`, `nat.public_ip`, `nat.port_min`, `nat.port_max`) to `upf_u.yaml` and corresponding parsing and validation logic in the code. This enables dynamic NAT on the N6 interface with configurable public IP and port range.
* Brought back global variables for NAT state (`g_nat_enabled`, `g_nat_public_ip_be`, `g_nat_port_min`, `g_nat_port_max`) and next-hop IPs (`g_an_peer_n3_ip_be`, `g_dn_peer_n6_ip_be`), since FABNETV4 connection needed them. These are set from the configuration and used throughout the datapath.

**Packet processing enhancements:**

* Integrated NAT logic into the packet handler: packets on N6 undergo SNAT/DNAT as appropriate, with proper error handling and packet drops on NAT misses. Also ensured that packets destined for the NAT public IP are not handled as local ICMP.

**Codebase structure:**

* Added a new header file `upf_u_nat.h` defining the NAT API, and included it where needed.
* Ensured NAT module is initialized at startup only if enabled in the configuration.