### PR TITLE
upf: introduce a non-blocking GFBR-first shaper

### DIFF
--- a/5gc/upf_u/Makefile
+++ b/5gc/upf_u/Makefile
@@ -51,6 +51,7 @@ APP = upf_u_complete
 
 # all source are stored in SRCS-y
 SRCS-y := upf_u.c
+SRCS-y += upf_u_shaper.c
 
 ONVM= $(SRCDIR)/../../onvm
 

--- a/5gc/upf_u/meson.build
+++ b/5gc/upf_u/meson.build
@@ -4,6 +4,7 @@ sources = files(
     'upf_u_arp.c',
     'upf_u_icmp.c',
     'upf_u_trtcm.c',
+    'upf_u_shaper.c',
     'upf_u_nat.c',
     'upf_u_helper.c'
 )

--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -18,13 +18,11 @@
 
 #include <errno.h>
 #include <getopt.h>
-#include <inttypes.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/queue.h>
 #include <unistd.h>
 #include <stdbool.h>
 
@@ -34,6 +32,9 @@
 #include <rte_ether.h>
 #include <rte_mbuf.h>
 #include <rte_meter.h>
+#include <rte_malloc.h>
+#include <rte_ring.h>
+#include <rte_tcp.h>
 
 #include "gtp.h"
 #include "upf_context.h"
@@ -55,6 +56,7 @@
 #include "upf_u_arp.h"
 #include "upf_u_icmp.h"
 #include "upf_u_nat.h"
+#include "upf_u_shaper.h"
 #include "upf_u_trtcm.h"
 
 #define NF_TAG "upf_u"
@@ -524,6 +526,9 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
     UPDK_PDR *pdr = NULL;
     gtp_parse_result_t gtp_info = {0};
     int ue_idx = -1;
+    UpfSession *owner_session = NULL;
+    uint32_t ue_key = 0;
+    struct upf_u_shaper_flow_key dl_flow_key = {0};
 
     /* char *src_address = convertToIpAddressString(iph->src_addr);
     UTLT_Info("Src IP is %s\n", src_address);
@@ -576,10 +581,16 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
     UTLT_Info("Got PDR ID is %u\n", pdr->pdrId);
 
     if (is_dl) {
-        uint32_t ue_key = rte_cpu_to_be_32(iph->dst_addr);
+        ue_key = rte_cpu_to_be_32(iph->dst_addr);
         ue_idx = findIndexByUeIpAddress(ue_key);
         if (ue_idx < 0) {
             ue_idx = GetQerByUEIpAddressFromPdr(ue_key, pdr, convertToIpAddressString(iph->dst_addr));
+        }
+        if (!upf_u_shaper_build_dl_flow_key(pkt, pdr, ue_key, pdr->has_fd,
+                                            &dl_flow_key)) {
+            UTLT_Error("Failed to build DL shaper flow key");
+            meta->action = ONVM_NF_ACTION_DROP;
+            return 0;
         }
     }
 
@@ -676,7 +687,9 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
             goto dl_nocp;
         }
 
-        /* QoS policing — FORW only */
+        /* QoS shaping — FORW only, after GTP-U/L2 TX prep is complete.
+         * Over-token packets wait in bounded per-flow FIFOs; only red,
+         * invalid, or queue-overflow packets drop. */
         if (far_action == UPDK_FAR_APPLY_ACTION_FORW) {
             if (ue_idx < 0) {
                 UTLT_Error("No UE IP found in the table");
@@ -710,25 +723,29 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
 
             if (isQos) {
                 if (meta->flags == RTE_COLOR_RED) {
-                    meta->action = ONVM_NF_ACTION_DROP;
+                    upf_u_shaper_drop_red(meta);
                     goto dl_nocp;
                 }
-                if (meta->flags == RTE_COLOR_GREEN) {
-                    ue_table[ue_idx].ue_qos_tb_params.tb_tokens -= cal_pktlen;
-                }
-                if (meta->flags == RTE_COLOR_YELLOW) {
-                    while (ue_table[ue_idx].ue_qos_tb_params.tb_tokens < cal_pktlen) {
-                        updateTokenbyIndex(ue_idx);
-                        usleep(1);
-                    }
-                    ue_table[ue_idx].ue_qos_tb_params.tb_tokens -= cal_pktlen;
+                if (meta->flags == RTE_COLOR_GREEN ||
+                    meta->flags == RTE_COLOR_YELLOW) {
+                    enum upf_u_shaper_pkt_color color =
+                        (meta->flags == RTE_COLOR_GREEN) ?
+                        UPF_U_SHAPER_COLOR_GREEN :
+                        UPF_U_SHAPER_COLOR_YELLOW;
+                    enum upf_u_shaper_decision decision =
+                        upf_u_shaper_shape_or_enqueue(
+                            ue_idx, &dl_flow_key, true, color, pkt,
+                            cal_pktlen, meta);
+                    if (decision != UPF_U_SHAPER_PASS)
+                        goto dl_nocp;
                 }
             } else {
-                while (ue_table[ue_idx].ue_nqos_tb_params.tb_tokens < cal_pktlen) {
-                    updateTokenbyIndex(ue_idx);
-                    usleep(1);
-                }
-                ue_table[ue_idx].ue_nqos_tb_params.tb_tokens -= cal_pktlen;
+                enum upf_u_shaper_decision decision =
+                    upf_u_shaper_shape_or_enqueue(
+                        ue_idx, &dl_flow_key, false,
+                        UPF_U_SHAPER_COLOR_NQOS, pkt, cal_pktlen, meta);
+                if (decision != UPF_U_SHAPER_PASS)
+                    goto dl_nocp;
             }
         }
 
@@ -869,6 +886,27 @@ msg_handler(void *msg_data, struct onvm_nf_local_ctx *nf_local_ctx) {
     if (e) rte_free(e);
 }
 
+static uint64_t last_p = 0;
+
+static int
+callback_handler(struct onvm_nf_local_ctx *nf_local_ctx) {
+    if (unlikely(!last_p)) last_p = rte_get_tsc_cycles();
+    uint64_t cur_p = rte_get_tsc_cycles();
+    struct onvm_nf *nf = nf_local_ctx->nf;
+
+    upf_u_shaper_drain(nf);
+
+    if (unlikely(cur_p - last_p > rte_get_timer_hz())) {
+        last_p = cur_p;
+        UTLT_Debug("Stats perform: ");
+        UTLT_Debug("act out: %d", nf->stats.act_out);
+        UTLT_Debug("buffered: %d", nf->stats.tx_buffer);
+        upf_u_shaper_log_stats();
+    }
+
+    return 0;
+}
+
 int
 main(int argc, char *argv[]) {
     int arg_offset;
@@ -881,6 +919,7 @@ main(int argc, char *argv[]) {
     nf_function_table = onvm_nflib_init_nf_function_table();
     nf_function_table->pkt_handler = &packet_handler;
     nf_function_table->msg_handler = &msg_handler;
+    nf_function_table->user_actions = &callback_handler;
 
     if ((arg_offset = onvm_nflib_init(argc, argv, NF_TAG, nf_local_ctx, nf_function_table)) < 0) {
         onvm_nflib_stop(nf_local_ctx);
@@ -940,8 +979,13 @@ main(int argc, char *argv[]) {
         nat_init();
     }
 
+    if (upf_u_shaper_init(nf_local_ctx->nf) < 0) {
+        rte_exit(EXIT_FAILURE, "Failed to init UPF-U shaper entry pool.\n");
+    }
+
     onvm_nflib_run(nf_local_ctx);
 
+    upf_u_shaper_cleanup();
     onvm_nflib_stop(nf_local_ctx);
     return 0;
 }

--- a/5gc/upf_u/upf_u_shaper.c
+++ b/5gc/upf_u/upf_u_shaper.c
@@ -1,0 +1,844 @@
+/*
+# Copyright 2026 University of California, Riverside and National Yang Ming Chiao Tung University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+*/
+
+#include <inttypes.h>
+#include <limits.h>
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/queue.h>
+
+#include <rte_common.h>
+#include <rte_cycles.h>
+#include <rte_ether.h>
+#include <rte_ip.h>
+#include <rte_malloc.h>
+#include <rte_mbuf.h>
+#include <rte_mempool.h>
+#include <rte_spinlock.h>
+#include <rte_tcp.h>
+#include <rte_udp.h>
+
+#include "onvm_pkt_helper.h"
+#include "upf_context.h"
+#include "utlt_debug.h"
+
+#include "upf_u_shaper.h"
+#include "upf_u_trtcm.h"
+
+#define SHAPER_SCAN_BUDGET       32
+#define SHAPER_DRAIN_BUDGET      64
+#define SHAPER_CLASS_BURST        8
+#define SHAPER_DRAIN_CHUNK       64
+#define SHAPER_MAX_FLOWS_PER_UE  64
+#define SHAPER_MAX_PKTS_PER_FLOW 256
+#define SHAPER_MAX_PKTS_PER_UE   1024
+#define SHAPER_ENTRY_POOL_CACHE  256
+#define SHAPER_UE_BITMAP_WORDS   ((MAX_UE + 63) / 64)
+
+enum shaper_active_list_id {
+    SHAPER_ACTIVE_NONE = 0,
+    SHAPER_ACTIVE_GREEN,
+    SHAPER_ACTIVE_YELLOW,
+    SHAPER_ACTIVE_NQOS,
+    SHAPER_ACTIVE_COUNT
+};
+
+struct shaper_entry {
+    struct rte_mbuf *pkt;
+    uint32_t pkt_len;
+    uint16_t destination;
+    enum upf_u_shaper_pkt_color color;
+    struct shaper_entry *next;
+};
+
+struct shaper_flow {
+    bool in_use;
+    struct upf_u_shaper_flow_key key;
+    struct shaper_entry *head;
+    struct shaper_entry *tail;
+    uint32_t queued_pkts;
+    uint32_t queued_bytes;
+    enum shaper_active_list_id active_list;
+    uint64_t last_active_tsc;
+    TAILQ_ENTRY(shaper_flow) active_node;
+};
+
+TAILQ_HEAD(shaper_flow_head, shaper_flow);
+
+struct ue_shaper {
+    rte_spinlock_t lock;
+    struct shaper_flow flows[SHAPER_MAX_FLOWS_PER_UE];
+    struct shaper_flow_head active[SHAPER_ACTIVE_COUNT];
+    uint32_t active_count[SHAPER_ACTIVE_COUNT];
+    uint32_t queued_pkts;
+    uint8_t next_excess_is_yellow;
+};
+
+static struct ue_shaper g_ue_shaper[MAX_UE];
+static struct rte_mempool *g_shaper_entry_pool;
+static uint64_t g_shaper_active_ue_bitmap[SHAPER_UE_BITMAP_WORDS];
+static uint32_t g_shaper_active_ue_cursor;
+static uint64_t g_shaper_queued;
+static uint64_t g_shaper_drained;
+static uint64_t g_shaper_drop_invalid;
+static uint64_t g_shaper_drop_red;
+static uint64_t g_shaper_drop_green_overflow;
+static uint64_t g_shaper_drop_yellow_overflow;
+static uint64_t g_shaper_drop_nqos_overflow;
+static uint64_t g_shaper_drop_flow_table_full;
+static uint64_t g_shaper_drop_flow_queue_full;
+static uint64_t g_shaper_drop_ue_queue_full;
+static uint64_t g_shaper_drop_mempool_empty;
+
+static int
+shaper_init_entry_pool(struct onvm_nf *nf) {
+    char name[64];
+    uint64_t entry_count64 = (uint64_t)MAX_UE * SHAPER_MAX_PKTS_PER_UE;
+    unsigned int entry_count;
+    uint16_t instance_id = nf ? nf->instance_id : 0;
+
+    if (g_shaper_entry_pool != NULL)
+        return 0;
+
+    if (entry_count64 == 0 || entry_count64 > UINT_MAX) {
+        UTLT_Error("Invalid shaper entry pool size: %" PRIu64,
+                   entry_count64);
+        return -1;
+    }
+    entry_count = (unsigned int)entry_count64;
+
+    snprintf(name, sizeof(name), "us_entry_%03u", instance_id);
+    g_shaper_entry_pool = rte_mempool_lookup(name);
+    if (g_shaper_entry_pool != NULL)
+        return 0;
+
+    g_shaper_entry_pool = rte_mempool_create(name, entry_count,
+                                             sizeof(struct shaper_entry),
+                                             SHAPER_ENTRY_POOL_CACHE, 0,
+                                             NULL, NULL, NULL, NULL,
+                                             SOCKET_ID_ANY, 0);
+    if (g_shaper_entry_pool == NULL)
+        g_shaper_entry_pool = rte_mempool_lookup(name);
+    if (g_shaper_entry_pool == NULL) {
+        UTLT_Error("Failed to create shaper entry pool %s", name);
+        return -1;
+    }
+    return 0;
+}
+
+static void
+shaper_init_state(void) {
+    for (uint32_t word_idx = 0; word_idx < SHAPER_UE_BITMAP_WORDS; word_idx++)
+        __atomic_store_n(&g_shaper_active_ue_bitmap[word_idx], 0,
+                         __ATOMIC_RELEASE);
+    g_shaper_active_ue_cursor = 0;
+
+    for (int ue_idx = 0; ue_idx < MAX_UE; ue_idx++) {
+        rte_spinlock_init(&g_ue_shaper[ue_idx].lock);
+        for (int list_id = 0; list_id < SHAPER_ACTIVE_COUNT; list_id++)
+            TAILQ_INIT(&g_ue_shaper[ue_idx].active[list_id]);
+        g_ue_shaper[ue_idx].next_excess_is_yellow = 1;
+    }
+}
+
+int
+upf_u_shaper_init(struct onvm_nf *nf) {
+    shaper_init_state();
+    return shaper_init_entry_pool(nf);
+}
+
+static inline void
+shaper_free_entry(struct shaper_entry *entry) {
+    if (entry != NULL && g_shaper_entry_pool != NULL)
+        rte_mempool_put(g_shaper_entry_pool, entry);
+}
+
+static inline uint64_t
+shaper_ue_bitmap_valid_mask(uint32_t word_idx) {
+    uint32_t used_bits;
+
+    if (word_idx + 1 < SHAPER_UE_BITMAP_WORDS)
+        return UINT64_MAX;
+
+    used_bits = MAX_UE & 63;
+    return used_bits == 0 ? UINT64_MAX : ((1ULL << used_bits) - 1);
+}
+
+static inline void
+shaper_mark_ue_active(int ue_idx) {
+    uint32_t word_idx = (uint32_t)ue_idx / 64;
+    uint64_t bit = 1ULL << ((uint32_t)ue_idx & 63);
+
+    __atomic_fetch_or(&g_shaper_active_ue_bitmap[word_idx], bit,
+                      __ATOMIC_RELEASE);
+}
+
+static inline void
+shaper_clear_ue_active(int ue_idx) {
+    uint32_t word_idx = (uint32_t)ue_idx / 64;
+    uint64_t bit = 1ULL << ((uint32_t)ue_idx & 63);
+
+    __atomic_fetch_and(&g_shaper_active_ue_bitmap[word_idx], ~bit,
+                       __ATOMIC_RELEASE);
+}
+
+static int
+shaper_next_active_ue(const uint64_t *skip_bitmap) {
+    uint32_t start = g_shaper_active_ue_cursor % MAX_UE;
+    uint32_t start_word = start / 64;
+    uint32_t start_bit = start & 63;
+
+    for (uint32_t pass = 0; pass < 2; pass++) {
+        uint32_t first_word = pass == 0 ? start_word : 0;
+        uint32_t last_word = pass == 0 ? SHAPER_UE_BITMAP_WORDS
+                                       : start_word + 1;
+
+        for (uint32_t word_idx = first_word; word_idx < last_word; word_idx++) {
+            uint64_t word = __atomic_load_n(&g_shaper_active_ue_bitmap[word_idx],
+                                            __ATOMIC_ACQUIRE);
+            word &= shaper_ue_bitmap_valid_mask(word_idx);
+            if (skip_bitmap != NULL)
+                word &= ~skip_bitmap[word_idx];
+            if (pass == 0 && word_idx == start_word) {
+                if (start_bit > 0)
+                    word &= UINT64_MAX << start_bit;
+            } else if (pass == 1 && word_idx == start_word) {
+                if (start_bit == 0)
+                    word = 0;
+                else
+                    word &= (1ULL << start_bit) - 1;
+            }
+            if (word == 0)
+                continue;
+
+            uint32_t bit = (uint32_t)__builtin_ctzll(word);
+            uint32_t ue_idx = word_idx * 64 + bit;
+            g_shaper_active_ue_cursor = (ue_idx + 1) % MAX_UE;
+            return (int)ue_idx;
+        }
+    }
+
+    return -1;
+}
+
+static inline bool
+shaper_flow_key_equal(const struct upf_u_shaper_flow_key *a,
+                      const struct upf_u_shaper_flow_key *b) {
+    return a->ue_ip == b->ue_ip &&
+           a->src_ip == b->src_ip &&
+           a->dst_ip == b->dst_ip &&
+           a->src_port == b->src_port &&
+           a->dst_port == b->dst_port &&
+           a->proto == b->proto &&
+           a->qfi == b->qfi &&
+           a->is_qos == b->is_qos;
+}
+
+static inline uint32_t
+shaper_flow_hash(const struct upf_u_shaper_flow_key *key) {
+    uint32_t h = 2166136261u;
+
+    h = (h ^ key->ue_ip) * 16777619u;
+    h = (h ^ key->src_ip) * 16777619u;
+    h = (h ^ key->dst_ip) * 16777619u;
+    h = (h ^ (((uint32_t)key->src_port << 16) | key->dst_port)) * 16777619u;
+    h = (h ^ (((uint32_t)key->proto << 16) |
+              ((uint32_t)key->qfi << 8) | key->is_qos)) * 16777619u;
+    return h;
+}
+
+static struct shaper_flow *
+shaper_lookup_flow(struct ue_shaper *ue,
+                   const struct upf_u_shaper_flow_key *key, bool create) {
+    uint32_t start = shaper_flow_hash(key) % SHAPER_MAX_FLOWS_PER_UE;
+    int free_idx = -1;
+
+    for (uint32_t probe = 0; probe < SHAPER_MAX_FLOWS_PER_UE; probe++) {
+        uint32_t idx = (start + probe) % SHAPER_MAX_FLOWS_PER_UE;
+        struct shaper_flow *flow = &ue->flows[idx];
+
+        if (flow->in_use) {
+            if (shaper_flow_key_equal(&flow->key, key))
+                return flow;
+            continue;
+        }
+        if (free_idx < 0)
+            free_idx = (int)idx;
+    }
+
+    if (!create || free_idx < 0)
+        return NULL;
+
+    struct shaper_flow *flow = &ue->flows[free_idx];
+    memset(flow, 0, sizeof(*flow));
+    flow->in_use = true;
+    flow->key = *key;
+    flow->active_list = SHAPER_ACTIVE_NONE;
+    return flow;
+}
+
+static inline enum shaper_active_list_id
+shaper_active_list_for_head(const struct shaper_flow *flow) {
+    if (flow == NULL || flow->head == NULL)
+        return SHAPER_ACTIVE_NONE;
+    if (!flow->key.is_qos)
+        return SHAPER_ACTIVE_NQOS;
+    switch (flow->head->color) {
+    case UPF_U_SHAPER_COLOR_GREEN:
+        return SHAPER_ACTIVE_GREEN;
+    case UPF_U_SHAPER_COLOR_YELLOW:
+        return SHAPER_ACTIVE_YELLOW;
+    default:
+        return SHAPER_ACTIVE_NONE;
+    }
+}
+
+static inline void
+shaper_activate_flow(struct ue_shaper *ue, struct shaper_flow *flow) {
+    enum shaper_active_list_id list_id = shaper_active_list_for_head(flow);
+
+    if (list_id == SHAPER_ACTIVE_NONE)
+        return;
+
+    if (flow->active_list != SHAPER_ACTIVE_NONE) {
+        TAILQ_REMOVE(&ue->active[flow->active_list], flow, active_node);
+        ue->active_count[flow->active_list]--;
+    }
+    TAILQ_INSERT_TAIL(&ue->active[list_id], flow, active_node);
+    ue->active_count[list_id]++;
+    flow->active_list = list_id;
+    flow->last_active_tsc = rte_get_tsc_cycles();
+}
+
+static inline void
+shaper_deactivate_flow(struct ue_shaper *ue, struct shaper_flow *flow) {
+    if (flow->active_list == SHAPER_ACTIVE_NONE)
+        return;
+    TAILQ_REMOVE(&ue->active[flow->active_list], flow, active_node);
+    ue->active_count[flow->active_list]--;
+    flow->active_list = SHAPER_ACTIVE_NONE;
+}
+
+static inline void
+shaper_release_empty_flow(struct ue_shaper *ue, struct shaper_flow *flow) {
+    shaper_deactivate_flow(ue, flow);
+    memset(flow, 0, sizeof(*flow));
+}
+
+static inline void
+shaper_count_overflow(enum upf_u_shaper_pkt_color color) {
+    if (color == UPF_U_SHAPER_COLOR_GREEN)
+        __atomic_fetch_add(&g_shaper_drop_green_overflow, 1, __ATOMIC_RELAXED);
+    else if (color == UPF_U_SHAPER_COLOR_YELLOW)
+        __atomic_fetch_add(&g_shaper_drop_yellow_overflow, 1, __ATOMIC_RELAXED);
+    else
+        __atomic_fetch_add(&g_shaper_drop_nqos_overflow, 1, __ATOMIC_RELAXED);
+}
+
+static inline bool
+shaper_class_has_backlog_locked(const struct ue_shaper *ue,
+                                enum ue_bucket_class bucket_class) {
+    switch (bucket_class) {
+    case UE_BUCKET_GREEN:
+        return ue->active_count[SHAPER_ACTIVE_GREEN] > 0;
+    case UE_BUCKET_YELLOW:
+    case UE_BUCKET_NQOS:
+        return ue->active_count[SHAPER_ACTIVE_GREEN] > 0 ||
+               ue->active_count[SHAPER_ACTIVE_YELLOW] > 0 ||
+               ue->active_count[SHAPER_ACTIVE_NQOS] > 0;
+    default:
+        return false;
+    }
+}
+
+static inline enum ue_bucket_class
+shaper_bucket_for_packet(bool is_qos,
+                         enum upf_u_shaper_pkt_color color) {
+    if (!is_qos)
+        return UE_BUCKET_NQOS;
+    if (color == UPF_U_SHAPER_COLOR_GREEN)
+        return UE_BUCKET_GREEN;
+    if (color == UPF_U_SHAPER_COLOR_YELLOW)
+        return UE_BUCKET_YELLOW;
+    return UE_BUCKET_NQOS;
+}
+
+enum upf_u_shaper_decision
+upf_u_shaper_shape_or_enqueue(int ue_idx,
+                              const struct upf_u_shaper_flow_key *key,
+                              bool is_qos,
+                              enum upf_u_shaper_pkt_color color,
+                              struct rte_mbuf *pkt, uint32_t pkt_len,
+                              struct onvm_pkt_meta *meta) {
+    struct ue_shaper *ue;
+    struct shaper_flow *flow;
+    struct shaper_entry *entry;
+    enum ue_bucket_class bucket_class =
+        shaper_bucket_for_packet(is_qos, color);
+
+    if (!ueBucketCanFitPacket(ue_idx, bucket_class, pkt_len)) {
+        meta->action = ONVM_NF_ACTION_DROP;
+        __atomic_fetch_add(&g_shaper_drop_invalid, 1, __ATOMIC_RELAXED);
+        return UPF_U_SHAPER_DROP;
+    }
+    if (unlikely(pkt == NULL || key == NULL || g_shaper_entry_pool == NULL)) {
+        meta->action = ONVM_NF_ACTION_DROP;
+        shaper_count_overflow(color);
+        return UPF_U_SHAPER_DROP;
+    }
+
+    ue = &g_ue_shaper[ue_idx];
+    rte_spinlock_lock(&ue->lock);
+
+    flow = shaper_lookup_flow(ue, key, false);
+    if (flow == NULL &&
+        !shaper_class_has_backlog_locked(ue, bucket_class) &&
+        consumeUeBucketTokens(ue_idx, bucket_class, pkt_len)) {
+        rte_spinlock_unlock(&ue->lock);
+        return UPF_U_SHAPER_PASS;
+    }
+
+    if (flow == NULL)
+        flow = shaper_lookup_flow(ue, key, true);
+    if (flow == NULL) {
+        rte_spinlock_unlock(&ue->lock);
+        meta->action = ONVM_NF_ACTION_DROP;
+        __atomic_fetch_add(&g_shaper_drop_flow_table_full, 1,
+                           __ATOMIC_RELAXED);
+        shaper_count_overflow(color);
+        return UPF_U_SHAPER_DROP;
+    }
+    if (flow->queued_pkts >= SHAPER_MAX_PKTS_PER_FLOW) {
+        rte_spinlock_unlock(&ue->lock);
+        meta->action = ONVM_NF_ACTION_DROP;
+        __atomic_fetch_add(&g_shaper_drop_flow_queue_full, 1,
+                           __ATOMIC_RELAXED);
+        shaper_count_overflow(color);
+        return UPF_U_SHAPER_DROP;
+    }
+    if (ue->queued_pkts >= SHAPER_MAX_PKTS_PER_UE) {
+        rte_spinlock_unlock(&ue->lock);
+        meta->action = ONVM_NF_ACTION_DROP;
+        __atomic_fetch_add(&g_shaper_drop_ue_queue_full, 1,
+                           __ATOMIC_RELAXED);
+        shaper_count_overflow(color);
+        return UPF_U_SHAPER_DROP;
+    }
+    if (rte_mempool_get(g_shaper_entry_pool, (void **)&entry) != 0) {
+        rte_spinlock_unlock(&ue->lock);
+        meta->action = ONVM_NF_ACTION_DROP;
+        __atomic_fetch_add(&g_shaper_drop_mempool_empty, 1,
+                           __ATOMIC_RELAXED);
+        shaper_count_overflow(color);
+        return UPF_U_SHAPER_DROP;
+    }
+
+    entry->pkt = pkt;
+    entry->pkt_len = pkt_len;
+    entry->destination = meta->destination;
+    entry->color = color;
+    entry->next = NULL;
+
+    rte_mbuf_refcnt_update(pkt, 1);
+    if (flow->tail != NULL)
+        flow->tail->next = entry;
+    else
+        flow->head = entry;
+    flow->tail = entry;
+    flow->queued_pkts++;
+    flow->queued_bytes += pkt_len;
+    ue->queued_pkts++;
+
+    if (flow->queued_pkts == 1)
+        shaper_activate_flow(ue, flow);
+    shaper_mark_ue_active(ue_idx);
+
+    rte_spinlock_unlock(&ue->lock);
+
+    __atomic_fetch_add(&g_shaper_queued, 1, __ATOMIC_RELAXED);
+    meta->action = ONVM_NF_ACTION_DROP;
+    return UPF_U_SHAPER_QUEUED;
+}
+
+void
+upf_u_shaper_drop_red(struct onvm_pkt_meta *meta) {
+    if (meta != NULL)
+        meta->action = ONVM_NF_ACTION_DROP;
+    __atomic_fetch_add(&g_shaper_drop_red, 1, __ATOMIC_RELAXED);
+}
+
+static bool
+shaper_drain_one_from_list_locked(int ue_idx,
+                                  enum shaper_active_list_id list_id,
+                                  enum ue_bucket_class bucket_class,
+                                  struct rte_mbuf **tx_buf,
+                                  uint32_t *nb_tx,
+                                  struct onvm_configuration *onvm_config) {
+    struct ue_shaper *ue = &g_ue_shaper[ue_idx];
+    uint32_t attempts = ue->active_count[list_id];
+
+    while (attempts-- > 0) {
+        struct shaper_flow *flow = TAILQ_FIRST(&ue->active[list_id]);
+        struct shaper_entry *entry;
+        struct rte_mbuf *pkt;
+
+        if (flow == NULL)
+            return false;
+
+        shaper_deactivate_flow(ue, flow);
+        entry = flow->head;
+        if (entry == NULL) {
+            shaper_release_empty_flow(ue, flow);
+            continue;
+        }
+
+        if (!ueBucketCanFitPacket(ue_idx, bucket_class, entry->pkt_len)) {
+            flow->head = entry->next;
+            if (flow->head == NULL)
+                flow->tail = NULL;
+            flow->queued_pkts--;
+            flow->queued_bytes -= entry->pkt_len;
+            ue->queued_pkts--;
+            rte_pktmbuf_free(entry->pkt);
+            shaper_free_entry(entry);
+            __atomic_fetch_add(&g_shaper_drop_invalid, 1, __ATOMIC_RELAXED);
+            if (flow->head != NULL)
+                shaper_activate_flow(ue, flow);
+            else
+                shaper_release_empty_flow(ue, flow);
+            continue;
+        }
+
+        if (!consumeUeBucketTokens(ue_idx, bucket_class, entry->pkt_len)) {
+            shaper_activate_flow(ue, flow);
+            continue;
+        }
+
+        flow->head = entry->next;
+        if (flow->head == NULL)
+            flow->tail = NULL;
+        flow->queued_pkts--;
+        flow->queued_bytes -= entry->pkt_len;
+        ue->queued_pkts--;
+
+        pkt = entry->pkt;
+        struct onvm_pkt_meta *m =
+            onvm_get_pkt_meta(pkt, onvm_config->dynfield_offset);
+        m->action = ONVM_NF_ACTION_OUT;
+        m->destination = entry->destination;
+        tx_buf[(*nb_tx)++] = pkt;
+
+        shaper_free_entry(entry);
+        if (flow->head != NULL)
+            shaper_activate_flow(ue, flow);
+        else
+            shaper_release_empty_flow(ue, flow);
+
+        __atomic_fetch_add(&g_shaper_drained, 1, __ATOMIC_RELAXED);
+        return true;
+    }
+
+    return false;
+}
+
+static uint32_t
+shaper_drain_service_locked(int ue_idx,
+                            enum shaper_active_list_id list_id,
+                            enum ue_bucket_class bucket_class,
+                            struct rte_mbuf **tx_buf,
+                            uint32_t *nb_tx,
+                            struct onvm_configuration *onvm_config,
+                            uint32_t budget) {
+    uint32_t sent = 0;
+
+    while (sent < budget &&
+           g_ue_shaper[ue_idx].active_count[list_id] > 0) {
+        if (!shaper_drain_one_from_list_locked(ue_idx, list_id,
+                                               bucket_class, tx_buf, nb_tx,
+                                               onvm_config))
+            break;
+        sent++;
+    }
+
+    return sent;
+}
+
+static uint32_t
+shaper_drain_green_locked(int ue_idx, struct rte_mbuf **tx_buf,
+                          uint32_t *nb_tx,
+                          struct onvm_configuration *onvm_config,
+                          uint32_t budget) {
+    return shaper_drain_service_locked(ue_idx, SHAPER_ACTIVE_GREEN,
+                                       UE_BUCKET_GREEN, tx_buf, nb_tx,
+                                       onvm_config, budget);
+}
+
+static uint32_t
+shaper_drain_excess_locked(int ue_idx, struct rte_mbuf **tx_buf,
+                           uint32_t *nb_tx,
+                           struct onvm_configuration *onvm_config,
+                           uint32_t budget) {
+    struct ue_shaper *ue = &g_ue_shaper[ue_idx];
+    uint32_t sent = 0;
+
+    while (sent < budget &&
+           (ue->active_count[SHAPER_ACTIVE_YELLOW] > 0 ||
+            ue->active_count[SHAPER_ACTIVE_NQOS] > 0)) {
+        bool prefer_yellow = ue->next_excess_is_yellow != 0;
+        enum shaper_active_list_id list_id = prefer_yellow ?
+            SHAPER_ACTIVE_YELLOW : SHAPER_ACTIVE_NQOS;
+        enum ue_bucket_class bucket_class = prefer_yellow ?
+            UE_BUCKET_YELLOW : UE_BUCKET_NQOS;
+        uint32_t n;
+
+        n = shaper_drain_service_locked(ue_idx, list_id, bucket_class,
+                                        tx_buf, nb_tx, onvm_config, 1);
+        ue->next_excess_is_yellow = !ue->next_excess_is_yellow;
+        if (n == 0) {
+            list_id = prefer_yellow ? SHAPER_ACTIVE_NQOS :
+                                      SHAPER_ACTIVE_YELLOW;
+            bucket_class = prefer_yellow ? UE_BUCKET_NQOS :
+                                           UE_BUCKET_YELLOW;
+            n = shaper_drain_service_locked(ue_idx, list_id, bucket_class,
+                                            tx_buf, nb_tx, onvm_config, 1);
+            if (n == 0)
+                break;
+        }
+        sent += n;
+    }
+
+    return sent;
+}
+
+static uint32_t
+drain_ue_shaper(int ue_idx, struct onvm_nf *nf, uint32_t budget) {
+    struct rte_mbuf *tx_buf[SHAPER_DRAIN_CHUNK];
+    struct onvm_configuration *onvm_config;
+    struct ue_shaper *ue;
+    uint32_t nb_tx = 0;
+    uint32_t total = 0;
+
+    if (ue_idx < 0 || ue_idx >= MAX_UE || nf == NULL || budget == 0)
+        return 0;
+
+    ue = &g_ue_shaper[ue_idx];
+    onvm_config = onvm_nflib_get_onvm_config();
+    rte_spinlock_lock(&ue->lock);
+    if (ue->queued_pkts == 0) {
+        shaper_clear_ue_active(ue_idx);
+        rte_spinlock_unlock(&ue->lock);
+        return 0;
+    }
+
+    while (budget > 0 && nb_tx < SHAPER_DRAIN_CHUNK &&
+           ue->queued_pkts > 0) {
+        bool sent = false;
+        uint32_t tx_room = SHAPER_DRAIN_CHUNK - nb_tx;
+        uint32_t burst = RTE_MIN(budget, (uint32_t)SHAPER_CLASS_BURST);
+        uint32_t n;
+
+        burst = RTE_MIN(burst, tx_room);
+        if (burst == 0)
+            break;
+
+        n = shaper_drain_green_locked(ue_idx, tx_buf, &nb_tx,
+                                      onvm_config, burst);
+        if (n > 0) {
+            total += n;
+            budget -= n;
+            sent = true;
+            if (budget == 0 || nb_tx == SHAPER_DRAIN_CHUNK)
+                break;
+        }
+
+        tx_room = SHAPER_DRAIN_CHUNK - nb_tx;
+        burst = RTE_MIN(budget, (uint32_t)SHAPER_CLASS_BURST);
+        burst = RTE_MIN(burst, tx_room);
+        if (burst == 0)
+            break;
+
+        n = shaper_drain_excess_locked(ue_idx, tx_buf, &nb_tx,
+                                       onvm_config, burst);
+        if (n > 0) {
+            total += n;
+            budget -= n;
+            sent = true;
+        }
+
+        if (!sent)
+            break;
+    }
+    if (ue->queued_pkts == 0)
+        shaper_clear_ue_active(ue_idx);
+    else
+        shaper_mark_ue_active(ue_idx);
+    rte_spinlock_unlock(&ue->lock);
+
+    if (nb_tx > 0) {
+        onvm_pkt_process_tx_batch(nf->nf_tx_mgr, tx_buf,
+                                  onvm_config->dynfield_offset, nb_tx, nf);
+        onvm_pkt_enqueue_tx_thread(nf->nf_tx_mgr->to_tx_buf, nf);
+    }
+    return total;
+}
+
+uint32_t
+upf_u_shaper_drain(struct onvm_nf *nf) {
+    uint64_t tried_ue_bitmap[SHAPER_UE_BITMAP_WORDS] = {0};
+    uint32_t total = 0;
+    uint32_t budget = SHAPER_DRAIN_BUDGET;
+
+    for (uint32_t visited = 0;
+         visited < SHAPER_SCAN_BUDGET && budget > 0;
+         visited++) {
+        int ue_idx = shaper_next_active_ue(tried_ue_bitmap);
+        uint32_t drained;
+
+        if (ue_idx < 0)
+            break;
+
+        tried_ue_bitmap[(uint32_t)ue_idx / 64] |=
+            1ULL << ((uint32_t)ue_idx & 63);
+        drained = drain_ue_shaper(ue_idx, nf, budget);
+        total += drained;
+        budget -= drained;
+    }
+
+    return total;
+}
+
+void
+upf_u_shaper_cleanup(void) {
+    for (int ue_idx = 0; ue_idx < MAX_UE; ue_idx++) {
+        struct ue_shaper *ue = &g_ue_shaper[ue_idx];
+
+        rte_spinlock_lock(&ue->lock);
+        for (int flow_idx = 0;
+             flow_idx < SHAPER_MAX_FLOWS_PER_UE;
+             flow_idx++) {
+            struct shaper_flow *flow = &ue->flows[flow_idx];
+            struct shaper_entry *entry = flow->head;
+
+            while (entry != NULL) {
+                struct shaper_entry *next = entry->next;
+                if (entry->pkt != NULL)
+                    rte_pktmbuf_free(entry->pkt);
+                shaper_free_entry(entry);
+                entry = next;
+            }
+            memset(flow, 0, sizeof(*flow));
+        }
+        ue->queued_pkts = 0;
+        ue->next_excess_is_yellow = 1;
+        for (int list_id = 0; list_id < SHAPER_ACTIVE_COUNT; list_id++) {
+            TAILQ_INIT(&ue->active[list_id]);
+            ue->active_count[list_id] = 0;
+        }
+        rte_spinlock_unlock(&ue->lock);
+    }
+    for (uint32_t word_idx = 0; word_idx < SHAPER_UE_BITMAP_WORDS; word_idx++)
+        __atomic_store_n(&g_shaper_active_ue_bitmap[word_idx], 0,
+                         __ATOMIC_RELEASE);
+    g_shaper_active_ue_cursor = 0;
+}
+
+bool
+upf_u_shaper_build_dl_flow_key(struct rte_mbuf *pkt, const UPDK_PDR *pdr,
+                               uint32_t ue_ip, bool is_qos,
+                               struct upf_u_shaper_flow_key *key) {
+    struct rte_ipv4_hdr *iph;
+    uint16_t l4_off;
+    uint32_t pkt_len;
+
+    if (pkt == NULL || key == NULL)
+        return false;
+
+    iph = onvm_pkt_ipv4_hdr(pkt);
+    if (iph == NULL || ((iph->version_ihl >> 4) != 4))
+        return false;
+
+    memset(key, 0, sizeof(*key));
+    key->ue_ip = ue_ip;
+    key->src_ip = rte_be_to_cpu_32(iph->src_addr);
+    key->dst_ip = rte_be_to_cpu_32(iph->dst_addr);
+    key->proto = iph->next_proto_id;
+    key->is_qos = is_qos ? 1 : 0;
+    key->qfi = (is_qos && pdr != NULL && pdr->qer != NULL) ?
+               QERGetQFI(pdr->qer) : 0;
+
+    l4_off = sizeof(struct rte_ether_hdr) +
+             ((iph->version_ihl & 0x0f) * 4);
+    pkt_len = rte_pktmbuf_pkt_len(pkt);
+    if (key->proto == IPPROTO_UDP &&
+        pkt_len >= l4_off + sizeof(struct rte_udp_hdr)) {
+        struct rte_udp_hdr udp_hdr;
+        const struct rte_udp_hdr *uh =
+            rte_pktmbuf_read(pkt, l4_off, sizeof(udp_hdr), &udp_hdr);
+        if (uh == NULL)
+            return false;
+        key->src_port = rte_be_to_cpu_16(uh->src_port);
+        key->dst_port = rte_be_to_cpu_16(uh->dst_port);
+    } else if (key->proto == IPPROTO_TCP &&
+               pkt_len >= l4_off + sizeof(struct rte_tcp_hdr)) {
+        struct rte_tcp_hdr tcp_hdr;
+        const struct rte_tcp_hdr *th =
+            rte_pktmbuf_read(pkt, l4_off, sizeof(tcp_hdr), &tcp_hdr);
+        if (th == NULL)
+            return false;
+        key->src_port = rte_be_to_cpu_16(th->src_port);
+        key->dst_port = rte_be_to_cpu_16(th->dst_port);
+    }
+
+    return true;
+}
+
+void
+upf_u_shaper_log_stats(void) {
+    UTLT_Debug("shaper queued: %" PRIu64,
+               __atomic_load_n(&g_shaper_queued, __ATOMIC_RELAXED));
+    UTLT_Debug("shaper drained: %" PRIu64,
+               __atomic_load_n(&g_shaper_drained, __ATOMIC_RELAXED));
+    UTLT_Debug("shaper invalid drops: %" PRIu64,
+               __atomic_load_n(&g_shaper_drop_invalid, __ATOMIC_RELAXED));
+    UTLT_Debug("shaper red drops: %" PRIu64,
+               __atomic_load_n(&g_shaper_drop_red, __ATOMIC_RELAXED));
+    UTLT_Debug("shaper green overflow drops: %" PRIu64,
+               __atomic_load_n(&g_shaper_drop_green_overflow,
+                               __ATOMIC_RELAXED));
+    UTLT_Debug("shaper yellow overflow drops: %" PRIu64,
+               __atomic_load_n(&g_shaper_drop_yellow_overflow,
+                               __ATOMIC_RELAXED));
+    UTLT_Debug("shaper non-QoS overflow drops: %" PRIu64,
+               __atomic_load_n(&g_shaper_drop_nqos_overflow,
+                               __ATOMIC_RELAXED));
+    UTLT_Debug("shaper flow table full drops: %" PRIu64,
+               __atomic_load_n(&g_shaper_drop_flow_table_full,
+                               __ATOMIC_RELAXED));
+    UTLT_Debug("shaper flow queue full drops: %" PRIu64,
+               __atomic_load_n(&g_shaper_drop_flow_queue_full,
+                               __ATOMIC_RELAXED));
+    UTLT_Debug("shaper UE queue full drops: %" PRIu64,
+               __atomic_load_n(&g_shaper_drop_ue_queue_full,
+                               __ATOMIC_RELAXED));
+    UTLT_Debug("shaper mempool empty drops: %" PRIu64,
+               __atomic_load_n(&g_shaper_drop_mempool_empty,
+                               __ATOMIC_RELAXED));
+}

--- a/5gc/upf_u/upf_u_shaper.h
+++ b/5gc/upf_u/upf_u_shaper.h
@@ -1,0 +1,81 @@
+/*
+# Copyright 2026 University of California, Riverside and National Yang Ming Chiao Tung University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+*/
+
+#ifndef UPF_U_SHAPER_H
+#define UPF_U_SHAPER_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <rte_mbuf.h>
+
+#include "onvm_nflib.h"
+#include "upf_context.h"
+
+enum upf_u_shaper_decision {
+    UPF_U_SHAPER_PASS = 0,
+    UPF_U_SHAPER_QUEUED,
+    UPF_U_SHAPER_DROP
+};
+
+enum upf_u_shaper_pkt_color {
+    UPF_U_SHAPER_COLOR_NQOS = 0,
+    UPF_U_SHAPER_COLOR_GREEN,
+    UPF_U_SHAPER_COLOR_YELLOW
+};
+
+struct upf_u_shaper_flow_key {
+    uint32_t ue_ip;
+    uint32_t src_ip;
+    uint32_t dst_ip;
+    uint16_t src_port;
+    uint16_t dst_port;
+    uint8_t proto;
+    uint8_t qfi;
+    uint8_t is_qos;
+};
+
+int
+upf_u_shaper_init(struct onvm_nf *nf);
+
+void
+upf_u_shaper_cleanup(void);
+
+bool
+upf_u_shaper_build_dl_flow_key(struct rte_mbuf *pkt, const UPDK_PDR *pdr,
+                               uint32_t ue_ip, bool is_qos,
+                               struct upf_u_shaper_flow_key *key);
+
+enum upf_u_shaper_decision
+upf_u_shaper_shape_or_enqueue(int ue_idx,
+                              const struct upf_u_shaper_flow_key *key,
+                              bool is_qos,
+                              enum upf_u_shaper_pkt_color color,
+                              struct rte_mbuf *pkt, uint32_t pkt_len,
+                              struct onvm_pkt_meta *meta);
+
+void
+upf_u_shaper_drop_red(struct onvm_pkt_meta *meta);
+
+uint32_t
+upf_u_shaper_drain(struct onvm_nf *nf);
+
+void
+upf_u_shaper_log_stats(void);
+
+#endif

--- a/5gc/upf_u/upf_u_trtcm.c
+++ b/5gc/upf_u/upf_u_trtcm.c
@@ -21,9 +21,15 @@
 #include "utlt_debug.h"
 #include "upf_u_config.h"
 
+#include <stdint.h>
+#include <string.h>
+
+#include <rte_spinlock.h>
+
 #include "../classifiers/classifier_wrapper.h"
 
-#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+#define MIN_TOKEN_BUCKET_DEPTH 2048
+#define TOKEN_BUCKET_BURST_MS 10
 
 flow_entry_t iPFlows[APP_FLOWS_MAX];
 uint32_t iPFlowsLen = 0;
@@ -35,6 +41,8 @@ struct rte_meter_trtcm app_flows[APP_FLOWS_MAX];
 
 static struct ue_hash_entry ue_hash[MAX_UE];
 struct ue_tb ue_table[MAX_UE];
+static rte_spinlock_t ue_table_lock;
+static rte_spinlock_t ue_tb_locks[MAX_UE];
 
 /* trTCM */
 struct rte_meter_trtcm_params app_trtcm_params = {
@@ -50,13 +58,13 @@ trtcmConfigFlowTables(void) {
     int rtn;
     if (likely(app_flows[0].tc > 0))
         return 0;
-    
+
     // config trtcm profile
     rtn = rte_meter_trtcm_profile_config(&app_trtcm_profile,
 		&app_trtcm_params);
 	if (rtn)
 		return rtn;
-        
+
     // config flow meters with trtcm profiles
     for (i = 0; i < APP_FLOWS_MAX; i++){
         rtn = rte_meter_trtcm_config(&app_flows[i], &app_trtcm_profile);
@@ -77,12 +85,12 @@ trtcmColorHandle(uint32_t pkt_len, uint64_t time, uint8_t qfi, struct rte_meter_
         return -1;
     }
     if (unlikely(app_trtcm_profile.pir_period == 0)) {
-        UTLT_Info("flow pir_period set err");    
+        UTLT_Info("flow pir_period set err");
         return -1;
     }
-    out_color = (uint8_t) rte_meter_trtcm_color_blind_check(&app_flows[qfi], 
-        target_profile, 
-        time, 
+    out_color = (uint8_t) rte_meter_trtcm_color_blind_check(&app_flows[qfi],
+        target_profile,
+        time,
         pkt_len);
     return out_color;
 }
@@ -158,7 +166,7 @@ ftSearch(uint32_t subnet) {
             return iPFlows[index].flow_idx;
         }
         index = (index + 1) % APP_FLOWS_MAX;  // Linear Probing
-        
+
         if (index == original_index) {
             break;
         }
@@ -193,35 +201,128 @@ ftAddEntry(uint32_t subnet, int flow_idx) {
     return true;
 }
 
-void 
+void
 initUeTable() {
+    rte_spinlock_init(&ue_table_lock);
     for (int i = 0; i < MAX_UE; i++) {
+        uint64_t now = rte_get_tsc_cycles();
+
+        rte_spinlock_init(&ue_tb_locks[i]);
         ue_table[i].ue_ip = 0;
         ue_table[i].ue_ambr = 0;
         ue_table[i].ue_gbr = 0;
         ue_table[i].ue_mbr = 0;
 
-        ue_table[i].ue_nqos_tb_params.tb_rate = 0;
-        ue_table[i].ue_nqos_tb_params.tb_depth = 0;
-        ue_table[i].ue_nqos_tb_params.tb_tokens = 0;
-        ue_table[i].ue_nqos_tb_params.last_cycle = rte_get_tsc_cycles();
-        ue_table[i].ue_nqos_tb_params.cur_cycles = rte_get_tsc_cycles();
+        ue_table[i].ue_green_tb_params.tb_rate = 0;
+        ue_table[i].ue_green_tb_params.tb_depth = 0;
+        ue_table[i].ue_green_tb_params.tb_tokens = 0;
+        ue_table[i].ue_green_tb_params.last_cycle = now;
+        ue_table[i].ue_green_tb_params.cur_cycles = now;
 
-        ue_table[i].ue_qos_tb_params.tb_rate = 0;
-        ue_table[i].ue_qos_tb_params.tb_depth = 0;
-        ue_table[i].ue_qos_tb_params.tb_tokens = 0;
-        ue_table[i].ue_qos_tb_params.last_cycle = rte_get_tsc_cycles();
-        ue_table[i].ue_qos_tb_params.cur_cycles = rte_get_tsc_cycles();
+        ue_table[i].ue_excess_tb_params.tb_rate = 0;
+        ue_table[i].ue_excess_tb_params.tb_depth = 0;
+        ue_table[i].ue_excess_tb_params.tb_tokens = 0;
+        ue_table[i].ue_excess_tb_params.last_cycle = now;
+        ue_table[i].ue_excess_tb_params.cur_cycles = now;
+
+        ue_table[i].ue_yellow_cap_tb_params.tb_rate = 0;
+        ue_table[i].ue_yellow_cap_tb_params.tb_depth = 0;
+        ue_table[i].ue_yellow_cap_tb_params.tb_tokens = 0;
+        ue_table[i].ue_yellow_cap_tb_params.last_cycle = now;
+        ue_table[i].ue_yellow_cap_tb_params.cur_cycles = now;
     }
 }
 
 static inline int
 ueHashFunc(uint32_t ip) { return ip % MAX_UE; }
 
+static inline bool
+ueHashSlotInUse(int idx) {
+    return __atomic_load_n(&ue_hash[idx].in_use, __ATOMIC_ACQUIRE);
+}
+
+static inline void
+ueHashSetInUse(int idx, bool in_use) {
+    __atomic_store_n(&ue_hash[idx].in_use, in_use, __ATOMIC_RELEASE);
+}
+
+static inline uint64_t
+shaper_bucket_depth(uint32_t rate_kbps) {
+    uint64_t depth_bytes;
+
+    if (rate_kbps == 0)
+        return 0;
+
+    depth_bytes = ((uint64_t)rate_kbps * TOKEN_BUCKET_BURST_MS + 7) / 8;
+    return depth_bytes < MIN_TOKEN_BUCKET_DEPTH ?
+           MIN_TOKEN_BUCKET_DEPTH : depth_bytes;
+}
+
+static inline void
+shaper_update_bucket_tokens(struct tb_config *tb, uint64_t cur_cycles) {
+    uint64_t elapsed_cycles;
+    uint64_t tokens_produced;
+    __uint128_t produced;
+
+    if (tb->tb_rate == 0 || tb->tb_depth == 0) {
+        tb->tb_tokens = 0;
+        tb->last_cycle = cur_cycles;
+        return;
+    }
+
+    if (tb->tb_tokens >= tb->tb_depth) {
+        tb->tb_tokens = tb->tb_depth;
+        tb->last_cycle = cur_cycles;
+        return;
+    }
+
+    elapsed_cycles = cur_cycles - tb->last_cycle;
+    produced = ((__uint128_t)elapsed_cycles * tb->tb_rate * 125) /
+               rte_get_tsc_hz();
+    tokens_produced = produced > UINT64_MAX ? UINT64_MAX :
+                      (uint64_t)produced;
+    if (tokens_produced == 0)
+        return;
+
+    tb->tb_tokens += tokens_produced;
+    if (tb->tb_tokens > tb->tb_depth)
+        tb->tb_tokens = tb->tb_depth;
+    tb->last_cycle = cur_cycles;
+}
+
+static inline bool
+ueTokenIndexValid(int index) {
+    return index > -1 && index < MAX_UE && ue_table[index].ue_ip != 0;
+}
+
+static inline void
+updateTokenbyIndexLocked(int index, uint64_t cur_cycles) {
+    shaper_update_bucket_tokens(&ue_table[index].ue_green_tb_params,
+                                cur_cycles);
+    shaper_update_bucket_tokens(&ue_table[index].ue_excess_tb_params,
+                                cur_cycles);
+    shaper_update_bucket_tokens(&ue_table[index].ue_yellow_cap_tb_params,
+                                cur_cycles);
+}
+
+static inline void
+initBucket(struct tb_config *tb, uint32_t rate, uint64_t now) {
+    tb->tb_rate = rate;
+    tb->tb_depth = shaper_bucket_depth(rate);
+    tb->tb_tokens = tb->tb_depth;
+    tb->last_cycle = now;
+    tb->cur_cycles = now;
+}
+
+static inline bool
+bucketCanFitPacket(const struct tb_config *tb, uint32_t pkt_len) {
+    return tb->tb_depth > 0 && pkt_len <= tb->tb_depth;
+}
+
 void
 ueHashInit(void) {
     for (int i = 0; i < MAX_UE; i++)
-        ue_hash[i].in_use = false;
+        ueHashSetInUse(i, false);
 }
 
 void
@@ -293,7 +394,7 @@ static inline int
 ueHashSearch(uint32_t ue_ip) {
     int idx = ueHashFunc(ue_ip);
     int start = idx;
-    while (ue_hash[idx].in_use) {
+    while (ueHashSlotInUse(idx)) {
         if (ue_hash[idx].ue_ip == ue_ip)
             return ue_hash[idx].ue_idx;
         idx = (idx + 1) % MAX_UE;
@@ -306,78 +407,192 @@ static inline bool
 ueHashInsert(uint32_t ue_ip, int ue_idx) {
     if (ueHashSearch(ue_ip) >= 0) return false; /* already present */
     int idx = ueHashFunc(ue_ip);
-    while (ue_hash[idx].in_use)
+    int start = idx;
+
+    while (ueHashSlotInUse(idx)) {
         idx = (idx + 1) % MAX_UE;
+        if (idx == start)
+            return false;
+    }
     ue_hash[idx].ue_ip  = ue_ip;
     ue_hash[idx].ue_idx = ue_idx;
-    ue_hash[idx].in_use = true;
+    ueHashSetInUse(idx, true);
     return true;
 }
 
 /* Legacy wrapper — now O(1) via hash */
-int 
+int
 findIndexByUeIpAddress(uint32_t ue_ip) {
     return ueHashSearch(ue_ip);
 }
 
 int
 addEntrybyUeIp(uint32_t ue_ip, uint32_t ue_ambr, uint32_t ue_gbr, uint32_t ue_mbr) {
+    int added_idx = -1;
+    int existing_idx;
+
+    if (ue_ambr == 0) {
+        UTLT_Warning("Reject UE %u shaper config with zero AMBR", ue_ip);
+        return -1;
+    }
+
+    if (ue_gbr > ue_ambr)
+        ue_gbr = ue_ambr;
+    if (ue_mbr == 0 || ue_mbr > ue_ambr)
+        ue_mbr = ue_ambr;
+    if (ue_gbr > ue_mbr)
+        ue_gbr = ue_mbr;
+
+    rte_spinlock_lock(&ue_table_lock);
+    existing_idx = ueHashSearch(ue_ip);
+    if (existing_idx >= 0) {
+        rte_spinlock_unlock(&ue_table_lock);
+        return existing_idx;
+    }
+
     for (int i = 0; i < MAX_UE; i++) {
         if (ue_table[i].ue_ip == 0) { // find unused
-            ue_table[i].ue_ip = ue_ip;
+            uint64_t now = rte_get_tsc_cycles();
+            uint32_t green_rate = ue_gbr;
+            uint32_t excess_rate = ue_ambr > ue_gbr ?
+                                   ue_ambr - ue_gbr : 0;
+            uint32_t yellow_cap_rate = ue_mbr > ue_gbr ?
+                                       ue_mbr - ue_gbr : 0;
+
+            rte_spinlock_lock(&ue_tb_locks[i]);
             ue_table[i].ue_ambr = ue_ambr;
             ue_table[i].ue_gbr = ue_gbr;
+            ue_table[i].ue_mbr = ue_mbr;
 
-            uint32_t qos_rate = MIN((ue_gbr + (ue_ambr - ue_gbr) / 2), ue_mbr);
+            initBucket(&ue_table[i].ue_green_tb_params, green_rate, now);
+            initBucket(&ue_table[i].ue_excess_tb_params, excess_rate, now);
+            initBucket(&ue_table[i].ue_yellow_cap_tb_params,
+                       yellow_cap_rate, now);
 
-            ue_table[i].ue_qos_tb_params.tb_rate = qos_rate / 1000;
-            ue_table[i].ue_qos_tb_params.tb_depth = qos_rate;
-            ue_table[i].ue_qos_tb_params.tb_tokens = qos_rate;
-            ue_table[i].ue_qos_tb_params.last_cycle = rte_get_tsc_cycles();
-            ue_table[i].ue_qos_tb_params.cur_cycles = rte_get_tsc_cycles();
-            UTLT_Info("QoS Rate: %d", qos_rate);
+            UTLT_Info("Green GFBR Rate: %u", green_rate);
+            UTLT_Info("Shared Excess Rate: %u", excess_rate);
+            UTLT_Info("Yellow Cap Rate: %u", yellow_cap_rate);
 
-            uint32_t nqos_rate = ue_ambr - qos_rate;
-
-            ue_table[i].ue_nqos_tb_params.tb_rate = nqos_rate / 1000;
-            ue_table[i].ue_nqos_tb_params.tb_depth = nqos_rate;
-            ue_table[i].ue_nqos_tb_params.tb_tokens = nqos_rate;
-            ue_table[i].ue_nqos_tb_params.last_cycle = rte_get_tsc_cycles();
-            ue_table[i].ue_nqos_tb_params.cur_cycles = rte_get_tsc_cycles();
-            UTLT_Info("non QoS Rate: %d", nqos_rate);
-
-            ueHashInsert(ue_ip, i);
-            return i;  // Return the allocated index
+            ue_table[i].ue_ip = ue_ip;
+            rte_spinlock_unlock(&ue_tb_locks[i]);
+            if (ueHashInsert(ue_ip, i)) {
+                added_idx = i;
+            } else {
+                rte_spinlock_lock(&ue_tb_locks[i]);
+                memset(&ue_table[i], 0, sizeof(ue_table[i]));
+                rte_spinlock_unlock(&ue_tb_locks[i]);
+                added_idx = ueHashSearch(ue_ip);
+            }
+            break;
         }
     }
-    return -1;  // Table full
+    rte_spinlock_unlock(&ue_table_lock);
+    return added_idx;  // Return the allocated index, or -1 if table full
 }
 
-void 
+void
 updateTokenbyIndex(int index) {
-    if (index > -1) {
-        uint64_t cur_cycles;
-        uint64_t elapsed_cycles;
-        uint64_t tokens_produced;
+    uint64_t cur_cycles;
 
-        cur_cycles = rte_get_tsc_cycles();
-        elapsed_cycles = cur_cycles - ue_table[index].ue_nqos_tb_params.last_cycle;
-
-        tokens_produced = (elapsed_cycles * ue_table[index].ue_nqos_tb_params.tb_rate * 125000) / rte_get_tsc_hz();
-        ue_table[index].ue_nqos_tb_params.tb_tokens += tokens_produced;
-        if (ue_table[index].ue_nqos_tb_params.tb_tokens > ue_table[index].ue_nqos_tb_params.tb_depth)
-            ue_table[index].ue_nqos_tb_params.tb_tokens = ue_table[index].ue_nqos_tb_params.tb_depth;
-        ue_table[index].ue_nqos_tb_params.last_cycle = cur_cycles;
-
-        elapsed_cycles = cur_cycles - ue_table[index].ue_qos_tb_params.last_cycle;
-        tokens_produced = (elapsed_cycles * ue_table[index].ue_qos_tb_params.tb_rate * 125000) / rte_get_tsc_hz();
-        ue_table[index].ue_qos_tb_params.tb_tokens += tokens_produced;
-        if (ue_table[index].ue_qos_tb_params.tb_tokens > ue_table[index].ue_qos_tb_params.tb_depth)
-            ue_table[index].ue_qos_tb_params.tb_tokens = ue_table[index].ue_qos_tb_params.tb_depth;
-        ue_table[index].ue_qos_tb_params.last_cycle = cur_cycles;
-
+    if (unlikely(index < 0 || index >= MAX_UE)) {
+        UTLT_Error("UE IP not found in the table");
         return;
     }
+
+    rte_spinlock_lock(&ue_tb_locks[index]);
+    if (ueTokenIndexValid(index)) {
+        cur_cycles = rte_get_tsc_cycles();
+        updateTokenbyIndexLocked(index, cur_cycles);
+        rte_spinlock_unlock(&ue_tb_locks[index]);
+        return;
+    }
+    rte_spinlock_unlock(&ue_tb_locks[index]);
     UTLT_Error("UE IP not found in the table");
-    return;
+}
+
+bool
+ueBucketCanFitPacket(int index, enum ue_bucket_class bucket_class, uint32_t pkt_len) {
+    bool can_fit;
+
+    if (unlikely(index < 0 || index >= MAX_UE))
+        return false;
+
+    rte_spinlock_lock(&ue_tb_locks[index]);
+    if (unlikely(!ueTokenIndexValid(index))) {
+        rte_spinlock_unlock(&ue_tb_locks[index]);
+        return false;
+    }
+
+    switch (bucket_class) {
+    case UE_BUCKET_GREEN:
+        can_fit = bucketCanFitPacket(&ue_table[index].ue_green_tb_params,
+                                     pkt_len);
+        break;
+    case UE_BUCKET_YELLOW:
+        can_fit = bucketCanFitPacket(&ue_table[index].ue_excess_tb_params,
+                                     pkt_len) &&
+                  bucketCanFitPacket(&ue_table[index].ue_yellow_cap_tb_params,
+                                     pkt_len);
+        break;
+    case UE_BUCKET_NQOS:
+        can_fit = bucketCanFitPacket(&ue_table[index].ue_excess_tb_params,
+                                     pkt_len);
+        break;
+    default:
+        can_fit = false;
+        break;
+    }
+    rte_spinlock_unlock(&ue_tb_locks[index]);
+    return can_fit;
+}
+
+bool
+consumeUeBucketTokens(int index, enum ue_bucket_class bucket_class, uint32_t pkt_len) {
+    struct tb_config *green_tb;
+    struct tb_config *excess_tb;
+    struct tb_config *yellow_cap_tb;
+    bool consumed = false;
+
+    if (unlikely(index < 0 || index >= MAX_UE))
+        return false;
+
+    rte_spinlock_lock(&ue_tb_locks[index]);
+    if (unlikely(!ueTokenIndexValid(index))) {
+        rte_spinlock_unlock(&ue_tb_locks[index]);
+        return false;
+    }
+
+    updateTokenbyIndexLocked(index, rte_get_tsc_cycles());
+
+    green_tb = &ue_table[index].ue_green_tb_params;
+    excess_tb = &ue_table[index].ue_excess_tb_params;
+    yellow_cap_tb = &ue_table[index].ue_yellow_cap_tb_params;
+
+    switch (bucket_class) {
+    case UE_BUCKET_GREEN:
+        if (green_tb->tb_tokens >= pkt_len) {
+            green_tb->tb_tokens -= pkt_len;
+            consumed = true;
+        }
+        break;
+    case UE_BUCKET_YELLOW:
+        if (excess_tb->tb_tokens >= pkt_len &&
+            yellow_cap_tb->tb_tokens >= pkt_len) {
+            excess_tb->tb_tokens -= pkt_len;
+            yellow_cap_tb->tb_tokens -= pkt_len;
+            consumed = true;
+        }
+        break;
+    case UE_BUCKET_NQOS:
+        if (excess_tb->tb_tokens >= pkt_len) {
+            excess_tb->tb_tokens -= pkt_len;
+            consumed = true;
+        }
+        break;
+    default:
+        break;
+    }
+
+    rte_spinlock_unlock(&ue_tb_locks[index]);
+    return consumed;
 }

--- a/5gc/upf_u/upf_u_trtcm.h
+++ b/5gc/upf_u/upf_u_trtcm.h
@@ -46,7 +46,7 @@ struct ue_hash_entry {
 
 /* Token Bucket */
 struct tb_config {
-    uint64_t tb_rate;    // rate at which tokens are generated (in MBps)
+    uint64_t tb_rate;    // token generation rate in Kbps
     uint64_t tb_depth;   // depth of the token bucket (in bytes)
     uint64_t tb_tokens;  // number of the tokens in the bucket at any given time (in bytes)
     uint64_t last_cycle;
@@ -54,13 +54,21 @@ struct tb_config {
     uint16_t used;
 };
 
+enum ue_bucket_class {
+    UE_BUCKET_GREEN = 0,
+    UE_BUCKET_YELLOW,
+    UE_BUCKET_NQOS,
+    UE_BUCKET_COUNT
+};
+
 struct ue_tb {
     uint32_t ue_ip;
     uint32_t ue_ambr;
     uint32_t ue_gbr;
     uint32_t ue_mbr;
-    struct tb_config ue_nqos_tb_params;
-    struct tb_config ue_qos_tb_params;
+    struct tb_config ue_green_tb_params;
+    struct tb_config ue_excess_tb_params;
+    struct tb_config ue_yellow_cap_tb_params;
 };
 
 extern flow_entry_t iPFlows[APP_FLOWS_MAX];
@@ -84,7 +92,7 @@ trtcmColorHandle(uint32_t pkt_len, uint64_t time, uint8_t qfi, struct rte_meter_
 int
 trtcmPolicer(struct onvm_pkt_meta *meta, int color_result);
 
-void 
+void
 initUeTable();
 
 void
@@ -96,11 +104,17 @@ ConfigureQerFlows(const UPDK_PDR *pdr, bool is_uplink);
 int
 ftSearch(uint32_t subnet);
 
-int 
+int
 findIndexByUeIpAddress(uint32_t ue_ip);
 
-void 
+void
 updateTokenbyIndex(int index);
+
+bool
+ueBucketCanFitPacket(int index, enum ue_bucket_class bucket_class, uint32_t pkt_len);
+
+bool
+consumeUeBucketTokens(int index, enum ue_bucket_class bucket_class, uint32_t pkt_len);
 
 int
 addEntrybyUeIp(uint32_t ue_ip, uint32_t ue_ambr, uint32_t ue_gbr, uint32_t ue_mbr);


### PR DESCRIPTION
This is PR 1 of 8 in the QoS shaper stack.

## Summary

- Replace the blocking UPF-U token shaper with bounded, non-blocking per-flow queues.
- Add per-UE buckets for guaranteed QoS, shared excess QoS, and default/non-QoS traffic.
- Prefer green/GFBR traffic across flows while preserving FIFO order within each flow.
- Drain queued packets incrementally from the NF callback and account for explicit drop paths.

## Why

The old shaping path could block the dataplane worker while waiting for tokens. It
also lacked the queue and scheduling structure needed to enforce GFBR-first service
without reordering packets within an ordered flow.

This change establishes the shaper foundation used by the correctness and rate
accounting fixes in the following PRs.

