### PR TITLE
upf: make trTCM metering flow-specific

### DIFF
--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -700,12 +700,11 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
             int color_result = 0;
             bool isQos = false;
             uint64_t curr_time = rte_get_tsc_cycles();
-            struct rte_meter_trtcm_profile *trtcm_profile = NULL;
 
             if (pdr->has_fd) {
                 isQos = true;
-                trtcm_profile = &app_flow_trtcm_profile;
                 int ft_idx = ftSearch(pdr->meter_key);
+                struct rte_meter_trtcm_profile *trtcm_profile;
                 if (unlikely(ft_idx < 0 || ft_idx >= (int)APP_FLOWS_MAX)) {
                     UTLT_Warning("DL QoS: no trTCM flow for meter_key=%u (ft_idx=%d) pdr=%u seid=%lu; dropping",
                                  pdr->meter_key, ft_idx, pdr->pdrId, seid);
@@ -713,8 +712,21 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
                     meta->action = ONVM_NF_ACTION_DROP;
                     goto dl_nocp;
                 }
+                trtcm_profile = trtcmProfileForFlow(ft_idx);
+                if (unlikely(trtcm_profile == NULL)) {
+                    UTLT_Warning("DL QoS: no trTCM profile for meter_key=%u ft_idx=%d pdr=%u seid=%lu; dropping",
+                                 pdr->meter_key, ft_idx, pdr->pdrId, seid);
+                    meta->flags = RTE_COLOR_RED;
+                    meta->action = ONVM_NF_ACTION_DROP;
+                    goto dl_nocp;
+                }
                 color_result = trtcmColorHandle(cal_pktlen, curr_time,
                                                 ft_idx, trtcm_profile);
+                if (unlikely(color_result < 0)) {
+                    meta->flags = RTE_COLOR_RED;
+                    meta->action = ONVM_NF_ACTION_DROP;
+                    goto dl_nocp;
+                }
                 // set the meta action to out for now, and trtcmPolicer will update it to drop if color is red
                 meta->action = ONVM_NF_ACTION_OUT;
                 if (trtcmPolicer(meta, color_result) > 0)
@@ -826,8 +838,22 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
                     }
 
                     uint64_t curr_time = rte_get_tsc_cycles();
+                    struct rte_meter_trtcm_profile *trtcm_profile =
+                        trtcmProfileForFlow(ft_idx);
+                    if (unlikely(trtcm_profile == NULL)) {
+                        UTLT_Warning("UL QoS: no trTCM profile for meter_key=%u ft_idx=%d pdr=%u seid=%lu; dropping",
+                                    pdr->meter_key, ft_idx, pdr->pdrId, seid);
+                        meta->flags = RTE_COLOR_RED;
+                        meta->action = ONVM_NF_ACTION_DROP;
+                        return 0;
+                    }
                     int color_result = trtcmColorHandle(pkt->pkt_len, curr_time,
-                                                        ft_idx, &app_flow_trtcm_profile);
+                                                        ft_idx, trtcm_profile);
+                    if (unlikely(color_result < 0)) {
+                        meta->flags = RTE_COLOR_RED;
+                        meta->action = ONVM_NF_ACTION_DROP;
+                        return 0;
+                    }
                     if (trtcmPolicer(meta, color_result) > 0)
                         UTLT_Error("UL trTCM Policer error");
 

--- a/5gc/upf_u/upf_u_trtcm.c
+++ b/5gc/upf_u/upf_u_trtcm.c
@@ -38,6 +38,7 @@ uint32_t trTCMidx = 0;
 struct rte_meter_trtcm_profile app_trtcm_profile;
 struct rte_meter_trtcm_profile app_flow_trtcm_profiles[APP_FLOWS_MAX];
 struct rte_meter_trtcm app_flows[APP_FLOWS_MAX];
+static bool app_flow_has_gbr[APP_FLOWS_MAX];
 
 static struct ue_hash_entry ue_hash[MAX_UE];
 struct ue_tb ue_table[MAX_UE];
@@ -68,6 +69,7 @@ trtcmConfigFlowTables(void) {
     // config flow meters with trtcm profiles
     for (i = 0; i < APP_FLOWS_MAX; i++){
         app_flow_trtcm_profiles[i] = app_trtcm_profile;
+        app_flow_has_gbr[i] = true;
         rtn = rte_meter_trtcm_config(&app_flows[i],
                                      &app_flow_trtcm_profiles[i]);
         if (rtn)
@@ -99,6 +101,8 @@ trtcmColorHandle(uint32_t pkt_len, uint64_t time, int flow_idx, struct rte_meter
         target_profile,
         time,
         pkt_len);
+    if (!app_flow_has_gbr[flow_idx] && out_color == RTE_COLOR_GREEN)
+        out_color = RTE_COLOR_YELLOW;
     return out_color;
 }
 
@@ -365,11 +369,12 @@ ConfigureQerFlows(const UPDK_PDR *pdr, bool is_uplink) {
     UTLT_Info("QER ID: %u key: %u", qer->qerId, key);
 
     struct rte_meter_trtcm_params trtcm_params = app_trtcm_params;
+    bool has_gbr = qer->flags.guaranteedBitrate;
 
     uint32_t mbr = is_uplink ? qer->maximumBitrate.ul : qer->maximumBitrate.dl;
     trtcm_params.pir = mbr * 1000 / 8;
 
-    if (qer->flags.guaranteedBitrate) {
+    if (has_gbr) {
         uint32_t gbr = is_uplink ? qer->guaranteedBitrate.ul : qer->guaranteedBitrate.dl;
         trtcm_params.cir = gbr * 1000 / 8;
     } else {
@@ -388,6 +393,7 @@ ConfigureQerFlows(const UPDK_PDR *pdr, bool is_uplink) {
         UTLT_Warning("TRTCM flow config failed for key %u: %d", key, rtn);
         return;
     }
+    app_flow_has_gbr[trTCMidx] = has_gbr;
 
     if (!ftAddEntry(key, trTCMidx)) {
         UTLT_Warning("FT add failed");

--- a/5gc/upf_u/upf_u_trtcm.c
+++ b/5gc/upf_u/upf_u_trtcm.c
@@ -36,7 +36,7 @@ uint32_t iPFlowsLen = 0;
 uint32_t trTCMidx = 0;
 
 struct rte_meter_trtcm_profile app_trtcm_profile;
-struct rte_meter_trtcm_profile app_flow_trtcm_profile;
+struct rte_meter_trtcm_profile app_flow_trtcm_profiles[APP_FLOWS_MAX];
 struct rte_meter_trtcm app_flows[APP_FLOWS_MAX];
 
 static struct ue_hash_entry ue_hash[MAX_UE];
@@ -67,7 +67,9 @@ trtcmConfigFlowTables(void) {
 
     // config flow meters with trtcm profiles
     for (i = 0; i < APP_FLOWS_MAX; i++){
-        rtn = rte_meter_trtcm_config(&app_flows[i], &app_trtcm_profile);
+        app_flow_trtcm_profiles[i] = app_trtcm_profile;
+        rtn = rte_meter_trtcm_config(&app_flows[i],
+                                     &app_flow_trtcm_profiles[i]);
         if (rtn)
             return rtn;
     }
@@ -77,22 +79,35 @@ trtcmConfigFlowTables(void) {
 }
 
 int
-trtcmColorHandle(uint32_t pkt_len, uint64_t time, uint8_t qfi, struct rte_meter_trtcm_profile *target_profile) {
+trtcmColorHandle(uint32_t pkt_len, uint64_t time, int flow_idx, struct rte_meter_trtcm_profile *target_profile) {
     uint8_t out_color = 0;
     // check configured flow
-    if (unlikely(app_trtcm_profile.cir_period == 0)) {
+    if (unlikely(flow_idx < 0 || flow_idx >= (int)APP_FLOWS_MAX ||
+                 target_profile == NULL)) {
+        UTLT_Info("flow index/profile set err");
+        return -1;
+    }
+    if (unlikely(target_profile->cir_period == 0)) {
         UTLT_Info("flow cir_period set err");
         return -1;
     }
-    if (unlikely(app_trtcm_profile.pir_period == 0)) {
+    if (unlikely(target_profile->pir_period == 0)) {
         UTLT_Info("flow pir_period set err");
         return -1;
     }
-    out_color = (uint8_t) rte_meter_trtcm_color_blind_check(&app_flows[qfi],
+    out_color = (uint8_t) rte_meter_trtcm_color_blind_check(&app_flows[flow_idx],
         target_profile,
         time,
         pkt_len);
     return out_color;
+}
+
+struct rte_meter_trtcm_profile *
+trtcmProfileForFlow(int flow_idx) {
+    if (unlikely(flow_idx < 0 || flow_idx >= (int)APP_FLOWS_MAX))
+        return NULL;
+
+    return &app_flow_trtcm_profiles[flow_idx];
 }
 
 int
@@ -342,6 +357,10 @@ ConfigureQerFlows(const UPDK_PDR *pdr, bool is_uplink) {
 
     /* Only add on first miss — subsequent packets for the same key are a no-op */
     if (ftSearch(key) >= 0) return;
+    if (unlikely(trTCMidx >= APP_FLOWS_MAX)) {
+        UTLT_Warning("TRTCM flow table full; cannot add key %u", key);
+        return;
+    }
 
     UTLT_Info("QER ID: %u key: %u", qer->qerId, key);
 
@@ -357,20 +376,24 @@ ConfigureQerFlows(const UPDK_PDR *pdr, bool is_uplink) {
         trtcm_params.cir = 1;
     }
 
+    int rtn = rte_meter_trtcm_profile_config(&app_flow_trtcm_profiles[trTCMidx],
+                                             &trtcm_params);
+    if (rtn) {
+        UTLT_Warning("TRTCM profile config failed for key %u: %d", key, rtn);
+        return;
+    }
+    rtn = rte_meter_trtcm_config(&app_flows[trTCMidx],
+                                 &app_flow_trtcm_profiles[trTCMidx]);
+    if (rtn) {
+        UTLT_Warning("TRTCM flow config failed for key %u: %d", key, rtn);
+        return;
+    }
+
     if (!ftAddEntry(key, trTCMidx)) {
         UTLT_Warning("FT add failed");
+        return;
     }
     UTLT_Info("Successfully add %u(%d) %u", key, hashFunc(key), trTCMidx);
-
-    // Match config profile to what color-check later uses:
-    // SDF present (has_fd) → app_flow_trtcm_profile; else app_trtcm_profile
-    if (has_fd) {
-        rte_meter_trtcm_profile_config(&app_flow_trtcm_profile, &trtcm_params);
-        rte_meter_trtcm_config(&app_flows[trTCMidx], &app_flow_trtcm_profile);
-    } else {
-        rte_meter_trtcm_profile_config(&app_trtcm_profile, &trtcm_params);
-        rte_meter_trtcm_config(&app_flows[trTCMidx], &app_trtcm_profile);
-    }
 
     if (is_uplink) {
         UTLT_Info("Find MBR (UL: %lu) in QERs", qer->maximumBitrate.ul);

--- a/5gc/upf_u/upf_u_trtcm.h
+++ b/5gc/upf_u/upf_u_trtcm.h
@@ -76,7 +76,7 @@ extern uint32_t iPFlowsLen;
 extern uint32_t trTCMidx;
 
 extern struct rte_meter_trtcm_profile app_trtcm_profile;
-extern struct rte_meter_trtcm_profile app_flow_trtcm_profile;
+extern struct rte_meter_trtcm_profile app_flow_trtcm_profiles[APP_FLOWS_MAX];
 extern struct rte_meter_trtcm app_flows[APP_FLOWS_MAX];
 
 extern struct rte_meter_trtcm_params app_trtcm_params;
@@ -87,7 +87,10 @@ int
 trtcmConfigFlowTables(void);
 
 int
-trtcmColorHandle(uint32_t pkt_len, uint64_t time, uint8_t qfi, struct rte_meter_trtcm_profile *target_profile);
+trtcmColorHandle(uint32_t pkt_len, uint64_t time, int flow_idx, struct rte_meter_trtcm_profile *target_profile);
+
+struct rte_meter_trtcm_profile *
+trtcmProfileForFlow(int flow_idx);
 
 int
 trtcmPolicer(struct onvm_pkt_meta *meta, int color_result);


### PR DESCRIPTION
This is PR 2 of 8 in the QoS shaper stack. It depends on #56.

## Summary

- Store a separate trTCM profile for every configured QoS flow.
- Resolve the matching profile from the flow-table index during DL and UL metering.
- Track whether a flow has GBR and remap accidental green results to yellow for
  Non-GBR QoS flows.

## Why

A shared mutable trTCM profile allowed the last configured QER to change metering
for earlier flows. In addition, a Non-GBR flow could occasionally be colored green
and then sent to a zero-depth guaranteed bucket, causing valid traffic to drop.

With these changes, each flow is metered with its own QER rates and Non-GBR QoS
traffic consistently uses the excess path.

