### PR TITLE
upf: aggregate UE GBR rates across QERs

### DIFF
--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -180,6 +180,11 @@ UpfClassifyGetPdrPtr(const ps_packet_t *key) {
     return (const UPDK_PDR *)descriptor;
 }
 
+static inline uint64_t
+saturating_add_u64(uint64_t lhs, uint64_t rhs) {
+    return UINT64_MAX - lhs < rhs ? UINT64_MAX : lhs + rhs;
+}
+
 UPDK_PDR *
 GetPdrByUeIpAddress(struct rte_mbuf *pkt, uint32_t ue_ip)
 {
@@ -296,6 +301,7 @@ GetQerByUEIpAddressFromPdr(uint32_t ue_ip, const UPDK_PDR *pdr, const char *ip_s
     uint64_t ambr64 = 0;
     uint64_t gbr64  = 0;
     uint64_t mbr64  = 0;
+    bool has_gbr_qer = false;
 
     int n = (int)pdr->qer_count;
     if (n > 2) n = 2; /* safety; struct currently supports 2 */
@@ -307,10 +313,10 @@ GetQerByUEIpAddressFromPdr(uint32_t ue_ip, const UPDK_PDR *pdr, const char *ip_s
         if (q->flags.maximumBitrate && q->maximumBitrate.dl > ambr64)
             ambr64 = q->maximumBitrate.dl;
 
-        /* old behavior: only set gbr/mbr when both flags are present */
         if (q->flags.guaranteedBitrate && q->flags.maximumBitrate) {
-            gbr64 = q->guaranteedBitrate.dl;
-            mbr64 = q->maximumBitrate.dl;
+            has_gbr_qer = true;
+            gbr64 = saturating_add_u64(gbr64, q->guaranteedBitrate.dl);
+            mbr64 = saturating_add_u64(mbr64, q->maximumBitrate.dl);
         }
     }
 
@@ -325,6 +331,8 @@ GetQerByUEIpAddressFromPdr(uint32_t ue_ip, const UPDK_PDR *pdr, const char *ip_s
     uint32_t gbr  = (gbr64  > UINT32_MAX) ? UINT32_MAX : (uint32_t)gbr64;
     uint32_t mbr  = (mbr64  > UINT32_MAX) ? UINT32_MAX : (uint32_t)mbr64;
 
+    if (!has_gbr_qer)
+        mbr = 0;
     if (mbr && gbr > mbr) gbr = mbr;
 
     UTLT_Warning("Add UE IP: %s, AMBR: %u GBR: %u, MBR: %u",


### PR DESCRIPTION
This is PR 3 of 8 in the QoS shaper stack. It depends on #57.

## Summary

- Sum DL GBR and MBR values from all GBR-bearing QERs for a UE.
- Use saturating 64-bit addition before clamping into the existing UE table fields.
- Preserve a zero MBR when the UE has no GBR QER.

## Why

The previous code overwrote GBR and MBR with whichever GBR-bearing QER was visited
last. A UE with multiple GBR/QFI flows could therefore reserve or cap the wrong
amount of guaranteed traffic.

