### PR TITLE
upf: account downlink QoS bytes by protocol

### DIFF
--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -516,7 +516,6 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
     uint32_t cal_pktlen = 0;
     UTLT_Trace("Get packet\n");
     UTLT_Info("Handle PKT from port: %d [len: %d]", pkt->port, pkt->pkt_len);
-    cal_pktlen = pkt->pkt_len - sizeof(struct rte_ether_hdr) - sizeof(struct rte_ipv4_hdr) - sizeof(struct rte_udp_hdr);
 
     bool is_dl = false;
     meta->action = ONVM_NF_ACTION_DROP;
@@ -527,6 +526,7 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
         UTLT_Info("Not IP packet, ignore it\n");
         return 0;
     }
+    cal_pktlen = upf_u_shaper_dl_packet_len(pkt, iph);
 
     // Flip to a newly published snapshot if a REQ was received
     UpfClsMaybeFlipAndAck();

--- a/5gc/upf_u/upf_u_shaper.c
+++ b/5gc/upf_u/upf_u_shaper.c
@@ -810,6 +810,61 @@ upf_u_shaper_build_dl_flow_key(struct rte_mbuf *pkt, const UPDK_PDR *pdr,
     return true;
 }
 
+uint32_t
+upf_u_shaper_dl_packet_len(struct rte_mbuf *pkt,
+                           const struct rte_ipv4_hdr *iph) {
+    uint16_t ip_total_len;
+    uint16_t ip_hdr_len;
+    uint16_t l4_payload_len;
+    uint16_t l4_off;
+    uint32_t pkt_len;
+
+    if (pkt == NULL || iph == NULL)
+        return 0;
+
+    ip_hdr_len = (uint16_t)((iph->version_ihl & 0x0f) * 4);
+    ip_total_len = rte_be_to_cpu_16(iph->total_length);
+    pkt_len = rte_pktmbuf_pkt_len(pkt);
+
+    if (ip_hdr_len < sizeof(struct rte_ipv4_hdr) ||
+        ip_total_len < ip_hdr_len ||
+        pkt_len < sizeof(struct rte_ether_hdr) + ip_hdr_len)
+        return 0;
+
+    l4_payload_len = ip_total_len - ip_hdr_len;
+    l4_off = sizeof(struct rte_ether_hdr) + ip_hdr_len;
+
+    if (iph->next_proto_id == IPPROTO_UDP) {
+        if (l4_payload_len >= sizeof(struct rte_udp_hdr) &&
+            pkt_len >= l4_off + sizeof(struct rte_udp_hdr))
+            return l4_payload_len - sizeof(struct rte_udp_hdr);
+        return l4_payload_len;
+    }
+
+    if (iph->next_proto_id == IPPROTO_TCP) {
+        struct rte_tcp_hdr tcp_hdr;
+        const struct rte_tcp_hdr *th;
+        uint16_t tcp_hdr_len;
+
+        if (l4_payload_len < sizeof(struct rte_tcp_hdr) ||
+            pkt_len < l4_off + sizeof(struct rte_tcp_hdr))
+            return l4_payload_len;
+
+        th = rte_pktmbuf_read(pkt, l4_off, sizeof(tcp_hdr), &tcp_hdr);
+        if (th == NULL)
+            return l4_payload_len;
+
+        tcp_hdr_len = (uint16_t)((th->data_off >> 4) * 4);
+        if (tcp_hdr_len < sizeof(struct rte_tcp_hdr) ||
+            tcp_hdr_len > l4_payload_len)
+            return l4_payload_len;
+
+        return l4_payload_len - tcp_hdr_len;
+    }
+
+    return l4_payload_len;
+}
+
 void
 upf_u_shaper_log_stats(void) {
     UTLT_Debug("shaper queued: %" PRIu64,

--- a/5gc/upf_u/upf_u_shaper.h
+++ b/5gc/upf_u/upf_u_shaper.h
@@ -22,6 +22,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include <rte_ip.h>
 #include <rte_mbuf.h>
 
 #include "onvm_nflib.h"
@@ -60,6 +61,10 @@ bool
 upf_u_shaper_build_dl_flow_key(struct rte_mbuf *pkt, const UPDK_PDR *pdr,
                                uint32_t ue_ip, bool is_qos,
                                struct upf_u_shaper_flow_key *key);
+
+uint32_t
+upf_u_shaper_dl_packet_len(struct rte_mbuf *pkt,
+                           const struct rte_ipv4_hdr *iph);
 
 enum upf_u_shaper_decision
 upf_u_shaper_shape_or_enqueue(int ue_idx,


### PR DESCRIPTION
This is PR 4 of 8 in the QoS shaper stack. It depends on #58.

## Summary

- Derive the metered DL length from the IPv4 total length and actual header size.
- Subtract UDP or TCP headers only when the packet uses that protocol.
- Handle TCP options and validate packet/header bounds before using the length.

## Why

The previous calculation always subtracted Ethernet, IPv4, and UDP header sizes.
TCP and other IPv4 traffic was therefore undercounted or counted inconsistently,
which made enforced bitrates drift from the configured QER rates.

