### PR TITLE
upf: preserve fractional shaper token refill

### DIFF
--- a/5gc/upf_u/upf_u_trtcm.c
+++ b/5gc/upf_u/upf_u_trtcm.c
@@ -293,7 +293,10 @@ trtcm_bucket_depth(uint32_t rate_kbps) {
 static inline void
 shaper_update_bucket_tokens(struct tb_config *tb, uint64_t cur_cycles) {
     uint64_t elapsed_cycles;
+    uint64_t cycles_used;
+    uint64_t tsc_hz;
     uint64_t tokens_produced;
+    __uint128_t byte_rate;
     __uint128_t produced;
 
     if (tb->tb_rate == 0 || tb->tb_depth == 0) {
@@ -309,17 +312,26 @@ shaper_update_bucket_tokens(struct tb_config *tb, uint64_t cur_cycles) {
     }
 
     elapsed_cycles = cur_cycles - tb->last_cycle;
-    produced = ((__uint128_t)elapsed_cycles * tb->tb_rate * 125) /
-               rte_get_tsc_hz();
+    tsc_hz = rte_get_tsc_hz();
+    byte_rate = (__uint128_t)tb->tb_rate * 125;
+    produced = ((__uint128_t)elapsed_cycles * byte_rate) / tsc_hz;
     tokens_produced = produced > UINT64_MAX ? UINT64_MAX :
                       (uint64_t)produced;
     if (tokens_produced == 0)
         return;
 
-    tb->tb_tokens += tokens_produced;
-    if (tb->tb_tokens > tb->tb_depth)
+    if (tokens_produced >= tb->tb_depth - tb->tb_tokens) {
         tb->tb_tokens = tb->tb_depth;
-    tb->last_cycle = cur_cycles;
+        tb->last_cycle = cur_cycles;
+        return;
+    }
+
+    tb->tb_tokens += tokens_produced;
+    cycles_used = (uint64_t)(((__uint128_t)tokens_produced * tsc_hz) /
+                             byte_rate);
+    if (cycles_used == 0)
+        cycles_used = 1;
+    tb->last_cycle += cycles_used;
 }
 
 static inline bool


### PR DESCRIPTION
This is PR 7 of 8 in the QoS shaper stack. It depends on #61.

## Summary

- Advance each bucket's timestamp only by the cycles consumed by whole credited
  byte tokens.
- Carry the remaining fractional elapsed time into the next refill.

## Why

The refill path rounded elapsed time down to whole bytes and then reset the full
timestamp. Frequent polling repeatedly discarded the fractional remainder, making
the effective output rate lower than configured. This explains observed plateaus
such as about 4.34 Mbps for a 5 Mbps cap and 5.5 Mbps for an 8 Mbps cap.

Preserving the remainder keeps long-term token production aligned with the
configured bitrate.

