### PR TITLE
upf: harden shaper packet validation and callbacks

### DIFF
--- a/5gc/upf_c/n4_onvm_pfcp_build.h
+++ b/5gc/upf_c/n4_onvm_pfcp_build.h
@@ -47,17 +47,6 @@ Status UpfN4BuildHeartbeatResponse (
         Bufblk **bufBlkPtr, uint8_t type);
 
 
-static inline int UpfSendEvt1(uint16_t dest_sid, uint32_t type, uintptr_t a0) {
-    Event *e = (Event *)rte_calloc("upf_evt", 1, sizeof(*e), 0);
-    if (!e) return -1;
-    e->type = (uintptr_t)type;
-    e->argc = 1;
-    e->arg0 = a0;
-    int rc = onvm_nflib_send_msg_to_nf(dest_sid, e);
-    if (rc < 0) rte_free(e);
-    return rc;
-}
-
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/5gc/upf_u/upf_u.c
+++ b/5gc/upf_u/upf_u.c
@@ -568,6 +568,7 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
     }
 
     uint32_t cal_pktlen = 0;
+    bool cal_pktlen_valid = false;
     UTLT_Trace("Get packet\n");
     UTLT_Info("Handle PKT from port: %d [len: %d]", pkt->port, pkt->pkt_len);
 
@@ -580,7 +581,8 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
         UTLT_Info("Not IP packet, ignore it\n");
         return 0;
     }
-    cal_pktlen = upf_u_shaper_dl_packet_len(pkt, iph);
+    cal_pktlen_valid =
+        upf_u_shaper_dl_packet_len(pkt, iph, &cal_pktlen);
 
     // Flip to a newly published snapshot if a REQ was received
     UpfClsMaybeFlipAndAck();
@@ -644,6 +646,13 @@ packet_handler(struct rte_mbuf *pkt, struct onvm_pkt_meta *meta, struct onvm_nf_
 
     if (is_dl) {
         ue_key = rte_cpu_to_be_32(iph->dst_addr);
+        if (!cal_pktlen_valid) {
+            UTLT_Warning("Invalid DL IPv4/L4 length for UE %s, drop",
+                         convertToIpAddressString(iph->dst_addr));
+            meta->action = ONVM_NF_ACTION_DROP;
+            return 0;
+        }
+        owner_session = UpfSessionFindByUeIP(ue_key);
         ue_idx = findIndexByUeIpAddress(ue_key);
         if (ue_idx < 0) {
             ue_idx = GetQerByUEIpAddressFromPdr(ue_key, owner_session, pdr,
@@ -979,9 +988,15 @@ static uint64_t last_p = 0;
 
 static int
 callback_handler(struct onvm_nf_local_ctx *nf_local_ctx) {
+    struct onvm_nf *nf;
+    uint64_t cur_p;
+
+    if (unlikely(nf_local_ctx == NULL || nf_local_ctx->nf == NULL))
+        return 0;
+
+    nf = nf_local_ctx->nf;
     if (unlikely(!last_p)) last_p = rte_get_tsc_cycles();
-    uint64_t cur_p = rte_get_tsc_cycles();
-    struct onvm_nf *nf = nf_local_ctx->nf;
+    cur_p = rte_get_tsc_cycles();
 
     upf_u_shaper_drain(nf);
 

--- a/5gc/upf_u/upf_u_shaper.c
+++ b/5gc/upf_u/upf_u_shaper.c
@@ -810,17 +810,20 @@ upf_u_shaper_build_dl_flow_key(struct rte_mbuf *pkt, const UPDK_PDR *pdr,
     return true;
 }
 
-uint32_t
+bool
 upf_u_shaper_dl_packet_len(struct rte_mbuf *pkt,
-                           const struct rte_ipv4_hdr *iph) {
+                           const struct rte_ipv4_hdr *iph,
+                           uint32_t *metered_len) {
     uint16_t ip_total_len;
     uint16_t ip_hdr_len;
     uint16_t l4_payload_len;
     uint16_t l4_off;
     uint32_t pkt_len;
 
-    if (pkt == NULL || iph == NULL)
-        return 0;
+    if (metered_len != NULL)
+        *metered_len = 0;
+    if (pkt == NULL || iph == NULL || metered_len == NULL)
+        return false;
 
     ip_hdr_len = (uint16_t)((iph->version_ihl & 0x0f) * 4);
     ip_total_len = rte_be_to_cpu_16(iph->total_length);
@@ -828,17 +831,17 @@ upf_u_shaper_dl_packet_len(struct rte_mbuf *pkt,
 
     if (ip_hdr_len < sizeof(struct rte_ipv4_hdr) ||
         ip_total_len < ip_hdr_len ||
-        pkt_len < sizeof(struct rte_ether_hdr) + ip_hdr_len)
-        return 0;
+        pkt_len < sizeof(struct rte_ether_hdr) + ip_total_len)
+        return false;
 
     l4_payload_len = ip_total_len - ip_hdr_len;
     l4_off = sizeof(struct rte_ether_hdr) + ip_hdr_len;
 
     if (iph->next_proto_id == IPPROTO_UDP) {
-        if (l4_payload_len >= sizeof(struct rte_udp_hdr) &&
-            pkt_len >= l4_off + sizeof(struct rte_udp_hdr))
-            return l4_payload_len - sizeof(struct rte_udp_hdr);
-        return l4_payload_len;
+        if (l4_payload_len < sizeof(struct rte_udp_hdr))
+            return false;
+        *metered_len = l4_payload_len - sizeof(struct rte_udp_hdr);
+        return true;
     }
 
     if (iph->next_proto_id == IPPROTO_TCP) {
@@ -846,23 +849,24 @@ upf_u_shaper_dl_packet_len(struct rte_mbuf *pkt,
         const struct rte_tcp_hdr *th;
         uint16_t tcp_hdr_len;
 
-        if (l4_payload_len < sizeof(struct rte_tcp_hdr) ||
-            pkt_len < l4_off + sizeof(struct rte_tcp_hdr))
-            return l4_payload_len;
+        if (l4_payload_len < sizeof(struct rte_tcp_hdr))
+            return false;
 
         th = rte_pktmbuf_read(pkt, l4_off, sizeof(tcp_hdr), &tcp_hdr);
         if (th == NULL)
-            return l4_payload_len;
+            return false;
 
         tcp_hdr_len = (uint16_t)((th->data_off >> 4) * 4);
         if (tcp_hdr_len < sizeof(struct rte_tcp_hdr) ||
             tcp_hdr_len > l4_payload_len)
-            return l4_payload_len;
+            return false;
 
-        return l4_payload_len - tcp_hdr_len;
+        *metered_len = l4_payload_len - tcp_hdr_len;
+        return true;
     }
 
-    return l4_payload_len;
+    *metered_len = l4_payload_len;
+    return true;
 }
 
 void

--- a/5gc/upf_u/upf_u_shaper.h
+++ b/5gc/upf_u/upf_u_shaper.h
@@ -62,9 +62,10 @@ upf_u_shaper_build_dl_flow_key(struct rte_mbuf *pkt, const UPDK_PDR *pdr,
                                uint32_t ue_ip, bool is_qos,
                                struct upf_u_shaper_flow_key *key);
 
-uint32_t
+bool
 upf_u_shaper_dl_packet_len(struct rte_mbuf *pkt,
-                           const struct rte_ipv4_hdr *iph);
+                           const struct rte_ipv4_hdr *iph,
+                           uint32_t *metered_len);
 
 enum upf_u_shaper_decision
 upf_u_shaper_shape_or_enqueue(int ue_idx,

--- a/onvm/utlt/upf_events.h
+++ b/onvm/utlt/upf_events.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include <stdint.h>
+
+#include <rte_malloc.h>
+
+#include "onvm_nflib.h"
+#include "utlt_event.h"
+
 // UPF-U service id = 1
 #ifndef UPF_U_SERVICE_ID
 #define UPF_U_SERVICE_ID  1 
@@ -17,4 +24,15 @@ enum {
         EVT_CLS_GC_ACK = 0x4202,
 };
 
+static inline int
+UpfSendEvt1(uint16_t dest_sid, uint32_t type, uintptr_t a0) {
+        Event *e = (Event *)rte_calloc("upf_evt", 1, sizeof(*e), 0);
+        if (!e) return -1;
+        e->type = (uintptr_t)type;
+        e->argc = 1;
+        e->arg0 = a0;
+        int rc = onvm_nflib_send_msg_to_nf(dest_sid, e);
+        if (rc < 0) rte_free(e);
+        return rc;
+}
 


### PR DESCRIPTION
This is PR 8 of 8 in the QoS shaper stack. It depends on #62.

## Summary

- Make downlink length parsing return an explicit validity result.
- Reject truncated or malformed IPv4/UDP/TCP lengths instead of shaping them with
  an ambiguous zero or fallback length.
- Resolve the owning session before first-use shaper registration.
- Guard the periodic callback against a missing NF context.
- Place the shared event sender in `upf_events.h`, where both UPF-C and UPF-U can
  include it directly.

## Why

These changes address review findings around malformed packet handling, null
callback state, first-packet session lookup, and the ownership of shared event
helpers. They keep failure behavior explicit and prevent invalid state from
reaching the shaper.

